### PR TITLE
allow local testing of s3 controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /docs/site
 bin
 build
+go.local.sum

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,15 @@ GO_LDFLAGS=-ldflags "-X main.version=$(VERSION) \
 			-X main.buildHash=$(GITCOMMIT) \
 			-X main.buildDate=$(BUILDDATE)"
 
-.PHONY: all test
+.PHONY: all test local-test
 
 all: test
 
 test: 				## Run code tests
 	go test -v ./...
+
+local-test: 		## Run code tests using go.local.mod file
+	go test -modfile=go.local.mod -v ./...
 
 help:           	## Show this help.
 	@grep -F -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \

--- a/go.local.mod
+++ b/go.local.mod
@@ -1,0 +1,17 @@
+module github.com/aws-controllers-k8s/s3-controller
+
+go 1.14
+
+replace github.com/aws-controllers-k8s/runtime => ../runtime
+
+require (
+	github.com/aws-controllers-k8s/runtime v0.0.4
+	github.com/aws/aws-sdk-go v1.37.4
+	github.com/go-logr/logr v0.1.0
+	github.com/google/go-cmp v0.3.1
+	github.com/spf13/pflag v1.0.5
+	k8s.io/api v0.18.2
+	k8s.io/apimachinery v0.18.6
+	k8s.io/client-go v0.18.2
+	sigs.k8s.io/controller-runtime v0.6.0
+)


### PR DESCRIPTION
Adds go.local.mod and Makefile target for testing the s3 controller with
locally-available runtime source repo.