### PR TITLE
Update workflow and refactor e2e test Python

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -11,14 +11,6 @@ on:
         description: 'Git ref for checking out the community repo. Default is main'
         required: false
         default: ''
-      codeGeneratorRepo:
-        description: 'Git repository for checking out the code-generator repo'
-        required: false
-        default: 'aws-controllers-k8s/code-generator'
-      codeGeneratorRef:
-        description: 'Git ref for checking out the code-generator repo. Default is main'
-        required: false
-        default: ''
       testInfraRepo:
         description: 'Git repository for checking out the test-infra repo'
         required: false
@@ -56,26 +48,12 @@ jobs:
           ref: ${{ github.event.inputs.communityRef }}
           path: './src/github.com/aws-controllers-k8s/community'
 
-      - name: checkout code-generator
-        uses: actions/checkout@v2
-        with:
-          repository: ${{ github.event.inputs.codeGeneratorRepo }}
-          ref: ${{ github.event.inputs.codeGeneratorRef }}
-          path: './src/github.com/aws-controllers-k8s/code-generator'
-
       - name: checkout test-infra
         uses: actions/checkout@v2
         with:
           repository: ${{ github.event.inputs.testInfraRepo }}
           ref: ${{ github.event.inputs.testInfraRef }}
           path: './src/github.com/aws-controllers-k8s/test-infra'
-
-      - name: build controller
-        working-directory: './src/github.com/aws-controllers-k8s/community'
-        run: ./scripts/build-controller.sh $SERVICE
-        env:
-          SERVICE: ${{ matrix.service }}
-          GOPATH: ${{ github.workspace }}
 
       - name: execute e2e tests
         working-directory: './src/github.com/aws-controllers-k8s/community'

--- a/test/e2e/__init__.py
+++ b/test/e2e/__init__.py
@@ -12,8 +12,11 @@
 # permissions and limitations under the License.
 
 import pytest
+from typing import Dict, Any
 from pathlib import Path
+
 from acktest.k8s import resource
+from acktest.resources import load_resource_file
 
 SERVICE_NAME = "s3"
 CRD_GROUP = "s3.services.k8s.aws"
@@ -22,7 +25,13 @@ CRD_VERSION = "v1alpha1"
 # PyTest marker for the current service
 service_marker = pytest.mark.service(arg=SERVICE_NAME)
 
+bootstrap_directory = Path(__file__).parent
 resource_directory = Path(__file__).parent / "resources"
+def load_s3_resource(resource_name: str, additional_replacements: Dict[str, Any] = {}):
+    """ Overrides the default `load_resource_file` to access the specific resources
+    directory for the current service.
+    """
+    return load_resource_file(resource_directory, resource_name, additional_replacements=additional_replacements)
 
 def create_s3_resource(
     resource_plural, resource_name, spec_file, replacements, namespace="default"
@@ -32,7 +41,7 @@ def create_s3_resource(
     """
 
     reference, spec, resource = resource.load_and_create_resource(
-        SERVICE_NAME,
+        resource_directory,
         CRD_GROUP,
         CRD_VERSION,
         resource_plural,

--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -15,8 +15,8 @@ for them.
 """
 from dataclasses import dataclass
 
+from e2e import bootstrap_directory
 from acktest.resources import read_bootstrap_config
-from e2e import SERVICE_NAME
 
 @dataclass
 class TestBootstrapResources:
@@ -24,8 +24,10 @@ class TestBootstrapResources:
 
 _bootstrap_resources = None
 
-def get_bootstrap_resources():
+def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.yaml"):
     global _bootstrap_resources
     if _bootstrap_resources is None:
-        _bootstrap_resources = TestBootstrapResources(**read_bootstrap_config(SERVICE_NAME))
+        _bootstrap_resources = TestBootstrapResources(
+            **read_bootstrap_config(bootstrap_directory, bootstrap_file_name=bootstrap_file_name),
+        )
     return _bootstrap_resources

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,4 +1,4 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@f9216390ff69b7defe2925dd65990364b37636f7
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@6c6d9dd4759c7bb2feecd11dc03e8516371812cc
 apipkg==1.5
 attrs==20.3.0
 boto3==1.16.40
@@ -23,7 +23,7 @@ pytest==6.2.3
 pytest-forked==1.3.0
 pytest-xdist==2.2.0
 python-dateutil==2.8.1
-PyYAML==5.4
+PyYAML==5.3.1
 requests==2.25.1
 requests-oauthlib==1.3.0
 rsa==4.7.2

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -17,6 +17,7 @@ import logging
 from pathlib import Path
 
 from acktest import resources
+from e2e import bootstrap_directory
 from e2e.bootstrap_resources import TestBootstrapResources
 
 
@@ -27,8 +28,5 @@ def service_bootstrap() -> dict:
     ).__dict__
 
 if __name__ == "__main__":
-    root_test_path = Path(__file__).parent
-    
     config = service_bootstrap()
-    # Write config to current directory by default
-    resources.write_bootstrap_config(config, root_test_path)
+    resources.write_bootstrap_config(config, bootstrap_directory)

--- a/test/e2e/service_cleanup.py
+++ b/test/e2e/service_cleanup.py
@@ -17,6 +17,7 @@ import logging
 from pathlib import Path
 
 from acktest import resources
+from e2e import bootstrap_directory
 from e2e.bootstrap_resources import TestBootstrapResources
 
 def service_cleanup(config: dict):
@@ -26,8 +27,6 @@ def service_cleanup(config: dict):
         **config
     )
 
-if __name__ == "__main__":
-    root_test_path = Path(__file__).parent
-    
-    bootstrap_config = resources.read_bootstrap_config(root_test_path)
+if __name__ == "__main__":   
+    bootstrap_config = resources.read_bootstrap_config(bootstrap_directory)
     service_cleanup(bootstrap_config) 


### PR DESCRIPTION
Last PR was merged a little too quickly, missed some minor changes to the tests.
- Removed code-generator from the workflow
- Updated `acktest` to latest SHA
- Updated the bootstrapping and test setup to be in line with other services