### PR TITLE
Properly capitalize capability level

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -1,6 +1,6 @@
 ---
 annotations:
-  capabilityLevel: basic install
+  capabilityLevel: Basic Install
   shortDescription: AWS S3 controller is a service controller for managing S3 resources
     in Kubernetes
 displayName: AWS Controllers for Kubernetes - Amazon S3


### PR DESCRIPTION
This fixes the rendering of the capability level as it shows up in the OpenShift Console. 

Apologies for the extra commit here. The OperatorHub preview functionality used to test the CSV layout is apparently more lenient than the OpenShift Console rendering in this regard.