### PR TITLE
chart: add namespace to ServiceAccount

### DIFF
--- a/helm/templates/service-account.yaml
+++ b/helm/templates/service-account.yaml
@@ -10,6 +10,7 @@ metadata:
     k8s-app: {{ include "app.name" . }}
     helm.sh/chart: {{ include "chart.name-version" . }}
   name: {{ include "service-account.name" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
   {{- range $key, $value := .Values.serviceAccount.annotations }}
     {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
ServiceAccounts are namespaced resources, so they should be placed in the chart's destination namespace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
