### PR TITLE
manifests: add name for container port

### DIFF
--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -41,7 +41,8 @@ spec:
         image: controller:latest
         name: controller
         ports:
-          - containerPort: 8080
+          - name: http
+            containerPort: 8080
         resources:
           limits:
             cpu: 100m

--- a/config/controller/service.yaml
+++ b/config/controller/service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - name: metricsport
       port: 8080
-      targetPort: 8080
+      targetPort: http
       protocol: TCP
   type: NodePort

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -54,7 +54,8 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         name: controller
         ports:
-          - containerPort: {{ .Values.deployment.containerPort }}
+          - name: http
+            containerPort: {{ .Values.deployment.containerPort }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         env:

--- a/helm/templates/metrics-service.yaml
+++ b/helm/templates/metrics-service.yaml
@@ -25,6 +25,6 @@ spec:
   ports:
   - name: metricsport
     port: 8080
-    targetPort: 8080
+    targetPort: http
     protocol: TCP
 {{- end }}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
So that tooling that only works with named container ports is usable with this operator's chart and kustomizations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
