### PR TITLE
Added note regarding use of AWS-ENDPOINT-URL in the values.yaml causes issue #1015

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -39,6 +39,7 @@ aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
   account_id: ""
+  # Specifying the EKS cluster's endpoint URL here causes issue #1015 - Leave it empty.
   endpoint_url: ""
 
 # log level for the controller


### PR DESCRIPTION
Issue #, if available: aws-controllers-k8s/community#1015

Description of changes:
The values.yaml has a value `endpoint_url`. This is a bit misleading as end users may add the EKS cluster endpoint URL here which causes issue aws-controllers-k8s/community#1015. Added a note to let users know that the value is not required for s3-controller.

```
aws:
  # If specified, use the AWS region for AWS API calls
  region: ""
  account_id: ""
  # Specifying the EKS cluster's endpoint URL here causes issue #1015 - Leave it empty.
  endpoint_url: ""
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
