### PR TITLE
release artifact for v0.0.6

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2021-10-08T18:41:11Z"
-  build_hash: 385779a205bea50e8762b76bc75cab957cf723b9
-  go_version: go1.15
+  build_date: "2021-10-12T16:58:37Z"
+  build_hash: 4b30ff5578e2f570d1c5b1741f3098be0d78e246
+  go_version: go1.16.5
   version: v0.15.1
 api_directory_checksum: dfcc21d3fc7fcd228ae29942f020128e7a3bdb8e
 api_version: v1alpha1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: s3-chart
 description: A Helm chart for the ACK service controller for Amazon Simple Storage Service (S3)
-version: v0.0.5
-appVersion: v0.0.5
+version: v0.0.6
+appVersion: v0.0.6
 home: https://github.com/aws-controllers-k8s/s3-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -61,8 +61,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: AWS_ACCOUNT_ID
-          value: {{ .Values.aws.account_id | quote }}
         - name: AWS_REGION
           value: {{ .Values.aws.region }}
         - name: AWS_ENDPOINT_URL

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/s3-controller
-  tag: v0.0.5
+  tag: v0.0.6
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -38,7 +38,6 @@ resources:
 aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
-  account_id: ""
   endpoint_url: ""
 
 # log level for the controller


### PR DESCRIPTION
Description of changes:
* artifacts for new s3 controller v0.0.6 release
* This is prerequisite to updating the community docs for removing aws-account-id flag

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
