### PR TITLE
Ignore UnsupportedArgument error for GetBucketAccelerateConfiguration in GovCloud regions

### DIFF
--- a/pkg/resource/bucket/hook.go
+++ b/pkg/resource/bucket/hook.go
@@ -299,7 +299,7 @@ func (rm *resourceManager) addPutFieldsToSpec(
 		// This method is not supported in every region, ignore any errors if
 		// we attempt to describe this property in a region in which it's not
 		// supported.
-		if awsErr, ok := ackerr.AWSError(err); ok && awsErr.Code() == "MethodNotAllowed" {
+		if awsErr, ok := ackerr.AWSError(err); ok && (awsErr.Code() == "MethodNotAllowed" || awsErr.Code() == "UnsupportedArgument") {
 			getAccelerateResponse = &svcsdk.GetBucketAccelerateConfigurationOutput{}
 		} else {
 			return err


### PR DESCRIPTION
This PR resolves [issue 1407](https://github.com/aws-controllers-k8s/community/issues/1407) related to S3 accelerate error handling in govcloud accounts.

Co-authored-by: Mike Lumetta <mike.lumetta@adhocteam.us>
Co-authored-by: Giang Nguyen <nguyen_giang@bah.com>
Co-authored-by: Manali Bhatt <bhatt_manali@bah.com>

Issue #, if available: 1407

Description of changes: This PR adds a check for the AWS error code `UnsupportedArgument` in `addPutFieldsToSpec` in pkg/resource/bucket/hook.go and uses the default transfer accelerate configuration for the spec if that error is returned. The `UnsupportedArgument` error is not documented by the S3 docs but is returned by the S3 API in GovCloud regions for us and other GovCloud users, as we documented in [this comment](https://github.com/aws-controllers-k8s/community/issues/1407#issuecomment-1218416033). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
