### PR TITLE
Add description for id and status field of the lifecycle spec

### DIFF
--- a/config/crd/bases/s3.services.k8s.aws_buckets.yaml
+++ b/config/crd/bases/s3.services.k8s.aws_buckets.yaml
@@ -402,6 +402,9 @@ spec:
                           type: object
                         id:
                           type: string
+                          description: Optional unique identifier of the rule.
+                            Must be a value no longer than 255 characters.
+                            If you don't provide one, Amazon S3 will assign an ID.
                         noncurrentVersionExpiration:
                           description: Specifies when noncurrent object versions expire.
                             Upon expiration, Amazon S3 permanently deletes the noncurrent

--- a/config/crd/bases/s3.services.k8s.aws_buckets.yaml
+++ b/config/crd/bases/s3.services.k8s.aws_buckets.yaml
@@ -439,6 +439,7 @@ spec:
                         prefix:
                           type: string
                         status:
+                          description: Whether the rule is active or inactive. Must be set to Enabled or Disabled.
                           type: string
                         transitions:
                           items:


### PR DESCRIPTION
Issue #, if available: Not available

Description of changes:
In order to clarify the use of the id and status field of the lifecycle spec, this PR adds description fields to both.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
