### PR TITLE
fix: deployment, service selector

### DIFF
--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -12,15 +12,18 @@ metadata:
   namespace: ack-system
   labels:
     control-plane: controller
+    name: ack-s3-controller
 spec:
   selector:
     matchLabels:
       control-plane: controller
+      name: ack-s3-controller
   replicas: 1
   template:
     metadata:
       labels:
         control-plane: controller
+        name: ack-s3-controller
     spec:
       containers:
       - command:

--- a/config/controller/service.yaml
+++ b/config/controller/service.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   selector:
     control-plane: controller
+    name: ack-s3-controller
   ports:
     - name: metricsport
       port: 8080


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Adjust the label selector for pods that avoids issues when multiple operators are deployed.

The `selector` `controller` is not sufficient for expected operation for the service or automated selection.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
