### PR TITLE
Add support for KMS and S3 references

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-01-10T21:53:42Z"
+  build_date: "2023-01-30T20:17:27Z"
   build_hash: 1b20baf45a0b73a11b296050322a384c705fa897
-  go_version: go1.17.5
+  go_version: go1.19.1
   version: v0.22.0
-api_directory_checksum: f50cdf03c85532166479736d285eaf6330f91d2b
+api_directory_checksum: 61bf9c754c1cf761928be02500c10af5218f4e28
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 4faed1acfe4aed4d9839e38c50b1c7ce1064bab2
+  file_checksum: 376d8e48bf7d0f436b428878b50a9c1c8d16b9a8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -26,6 +26,10 @@ resources:
       Analytics:
         custom_field:
           list_of: AnalyticsConfiguration
+      Analytics.StorageClassAnalysis.DataExport.Destination.S3BucketDestination.Bucket:
+        references:
+          resource: Bucket
+          path: Spec.Name
       CORS:
         from:
           operation: PutBucketCors
@@ -34,12 +38,21 @@ resources:
         from:
           operation: PutBucketEncryption
           path: ServerSideEncryptionConfiguration
+      Encryption.Rules.ApplyServerSideEncryptionByDefault.KmsMasterKeyID:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
       IntelligentTiering:
         custom_field:
           list_of: IntelligentTieringConfiguration
       Inventory:
         custom_field:
           list_of: InventoryConfiguration
+      Inventory.Destination.S3BucketDestination.Bucket:
+        references:
+          resource: Bucket
+          path: Spec.Name
       Lifecycle:
         from:
           operation: PutBucketLifecycleConfiguration
@@ -48,6 +61,10 @@ resources:
         from:
           operation: PutBucketLogging
           path: BucketLoggingStatus
+      Logging.LoggingEnabled.TargetBucket:
+        references:
+          resource: Bucket
+          path: Spec.Name
       Metrics:
         custom_field:
           list_of: MetricsConfiguration
@@ -71,6 +88,15 @@ resources:
         from:
           operation: PutBucketReplication
           path: ReplicationConfiguration
+      Replication.Rules.Destination.EncryptionConfiguration.ReplicaKMSKeyID:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
+      Replication.Rules.Destination.Bucket:
+        references:
+          resource: Bucket
+          path: Spec.Name
       RequestPayment:
         from:
           operation: PutBucketRequestPayment

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -100,8 +100,10 @@ type AnalyticsFilter struct {
 type AnalyticsS3BucketDestination struct {
 	Bucket          *string `json:"bucket,omitempty"`
 	BucketAccountID *string `json:"bucketAccountID,omitempty"`
-	Format          *string `json:"format,omitempty"`
-	Prefix          *string `json:"prefix,omitempty"`
+	// Reference field for Bucket
+	BucketRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"bucketRef,omitempty"`
+	Format    *string                                  `json:"format,omitempty"`
+	Prefix    *string                                  `json:"prefix,omitempty"`
 }
 
 // Specifies the lifecycle configuration for objects in an Amazon S3 bucket.
@@ -182,10 +184,10 @@ type CreateBucketConfiguration struct {
 // The container element for specifying the default Object Lock retention settings
 // for new objects placed in the specified bucket.
 //
-//    * The DefaultRetention settings require both a mode and a period.
+//   - The DefaultRetention settings require both a mode and a period.
 //
-//    * The DefaultRetention period can be either Days or Years but you must
-//    select one. You cannot specify Days and Years at the same time.
+//   - The DefaultRetention period can be either Days or Years but you must
+//     select one. You cannot specify Days and Years at the same time.
 type DefaultRetention struct {
 	Days *int64 `json:"days,omitempty"`
 }
@@ -226,6 +228,8 @@ type Destination struct {
 	AccessControlTranslation *AccessControlTranslation `json:"accessControlTranslation,omitempty"`
 	Account                  *string                   `json:"account,omitempty"`
 	Bucket                   *string                   `json:"bucket,omitempty"`
+	// Reference field for Bucket
+	BucketRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"bucketRef,omitempty"`
 	// Specifies encryption-related information for an Amazon S3 bucket that is
 	// a destination for replicated objects.
 	EncryptionConfiguration *EncryptionConfiguration `json:"encryptionConfiguration,omitempty"`
@@ -250,6 +254,8 @@ type Encryption struct {
 // a destination for replicated objects.
 type EncryptionConfiguration struct {
 	ReplicaKMSKeyID *string `json:"replicaKMSKeyID,omitempty"`
+	// Reference field for ReplicaKMSKeyID
+	ReplicaKMSKeyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"replicaKMSKeyRef,omitempty"`
 }
 
 // Container for all error elements.
@@ -376,6 +382,8 @@ type InventoryFilter struct {
 type InventoryS3BucketDestination struct {
 	AccountID *string `json:"accountID,omitempty"`
 	Bucket    *string `json:"bucket,omitempty"`
+	// Reference field for Bucket
+	BucketRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"bucketRef,omitempty"`
 	// Contains the type of server-side encryption used to encrypt the inventory
 	// results.
 	Encryption *InventoryEncryption `json:"encryption,omitempty"`
@@ -479,9 +487,11 @@ type Location struct {
 // (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html)
 // in the Amazon S3 API Reference.
 type LoggingEnabled struct {
-	TargetBucket *string        `json:"targetBucket,omitempty"`
-	TargetGrants []*TargetGrant `json:"targetGrants,omitempty"`
-	TargetPrefix *string        `json:"targetPrefix,omitempty"`
+	TargetBucket *string `json:"targetBucket,omitempty"`
+	// Reference field for TargetBucket
+	TargetBucketRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"targetBucketRef,omitempty"`
+	TargetGrants    []*TargetGrant                           `json:"targetGrants,omitempty"`
+	TargetPrefix    *string                                  `json:"targetPrefix,omitempty"`
 }
 
 // A container specifying replication metrics-related settings enabling replication
@@ -762,11 +772,11 @@ type ReplicationRule struct {
 //
 // For example:
 //
-//    * If you specify both a Prefix and a Tag filter, wrap these filters in
-//    an And tag.
+//   - If you specify both a Prefix and a Tag filter, wrap these filters in
+//     an And tag.
 //
-//    * If you specify a filter based on multiple tags, wrap the Tag elements
-//    in an And tag.
+//   - If you specify a filter based on multiple tags, wrap the Tag elements
+//     in an And tag.
 type ReplicationRuleAndOperator struct {
 	Prefix *string `json:"prefix,omitempty"`
 	Tags   []*Tag  `json:"tags,omitempty"`
@@ -893,7 +903,9 @@ type SSEKMSEncryptedObjects struct {
 // in the Amazon S3 API Reference.
 type ServerSideEncryptionByDefault struct {
 	KMSMasterKeyID *string `json:"kmsMasterKeyID,omitempty"`
-	SSEAlgorithm   *string `json:"sseAlgorithm,omitempty"`
+	// Reference field for KMSMasterKeyID
+	KMSMasterKeyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"kmsMasterKeyRef,omitempty"`
+	SSEAlgorithm    *string                                  `json:"sseAlgorithm,omitempty"`
 }
 
 // Specifies the default server-side-encryption configuration.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -229,6 +229,11 @@ func (in *AnalyticsS3BucketDestination) DeepCopyInto(out *AnalyticsS3BucketDesti
 		*out = new(string)
 		**out = **in
 	}
+	if in.BucketRef != nil {
+		in, out := &in.BucketRef, &out.BucketRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Format != nil {
 		in, out := &in.Format, &out.Format
 		*out = new(string)
@@ -894,6 +899,11 @@ func (in *Destination) DeepCopyInto(out *Destination) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.BucketRef != nil {
+		in, out := &in.BucketRef, &out.BucketRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EncryptionConfiguration != nil {
 		in, out := &in.EncryptionConfiguration, &out.EncryptionConfiguration
 		*out = new(EncryptionConfiguration)
@@ -958,6 +968,11 @@ func (in *EncryptionConfiguration) DeepCopyInto(out *EncryptionConfiguration) {
 		in, out := &in.ReplicaKMSKeyID, &out.ReplicaKMSKeyID
 		*out = new(string)
 		**out = **in
+	}
+	if in.ReplicaKMSKeyRef != nil {
+		in, out := &in.ReplicaKMSKeyRef, &out.ReplicaKMSKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1392,6 +1407,11 @@ func (in *InventoryS3BucketDestination) DeepCopyInto(out *InventoryS3BucketDesti
 		*out = new(string)
 		**out = **in
 	}
+	if in.BucketRef != nil {
+		in, out := &in.BucketRef, &out.BucketRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Encryption != nil {
 		in, out := &in.Encryption, &out.Encryption
 		*out = new(InventoryEncryption)
@@ -1725,6 +1745,11 @@ func (in *LoggingEnabled) DeepCopyInto(out *LoggingEnabled) {
 		in, out := &in.TargetBucket, &out.TargetBucket
 		*out = new(string)
 		**out = **in
+	}
+	if in.TargetBucketRef != nil {
+		in, out := &in.TargetBucketRef, &out.TargetBucketRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.TargetGrants != nil {
 		in, out := &in.TargetGrants, &out.TargetGrants
@@ -2774,6 +2799,11 @@ func (in *ServerSideEncryptionByDefault) DeepCopyInto(out *ServerSideEncryptionB
 		in, out := &in.KMSMasterKeyID, &out.KMSMasterKeyID
 		*out = new(string)
 		**out = **in
+	}
+	if in.KMSMasterKeyRef != nil {
+		in, out := &in.KMSMasterKeyRef, &out.KMSMasterKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SSEAlgorithm != nil {
 		in, out := &in.SSEAlgorithm, &out.SSEAlgorithm

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -52,6 +53,7 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = kmsapitypes.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/crd/bases/s3.services.k8s.aws_buckets.yaml
+++ b/config/crd/bases/s3.services.k8s.aws_buckets.yaml
@@ -111,6 +111,18 @@ spec:
                                       type: string
                                     bucketAccountID:
                                       type: string
+                                    bucketRef:
+                                      description: Reference field for Bucket
+                                      properties:
+                                        from:
+                                          description: AWSResourceReference provides
+                                            all the values necessary to reference
+                                            another k8s resource for finding the identifier(Id/ARN/Name)
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                      type: object
                                     format:
                                       type: string
                                     prefix:
@@ -186,6 +198,18 @@ spec:
                           properties:
                             kmsMasterKeyID:
                               type: string
+                            kmsMasterKeyRef:
+                              description: Reference field for KMSMasterKeyID
+                              properties:
+                                from:
+                                  description: AWSResourceReference provides all the
+                                    values necessary to reference another k8s resource
+                                    for finding the identifier(Id/ARN/Name)
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
                             sseAlgorithm:
                               type: string
                           type: object
@@ -291,6 +315,18 @@ spec:
                               type: string
                             bucket:
                               type: string
+                            bucketRef:
+                              description: Reference field for Bucket
+                              properties:
+                                from:
+                                  description: AWSResourceReference provides all the
+                                    values necessary to reference another k8s resource
+                                    for finding the identifier(Id/ARN/Name)
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
                             encryption:
                               description: Contains the type of server-side encryption
                                 used to encrypt the inventory results.
@@ -491,6 +527,18 @@ spec:
                     properties:
                       targetBucket:
                         type: string
+                      targetBucketRef:
+                        description: Reference field for TargetBucket
+                        properties:
+                          from:
+                            description: AWSResourceReference provides all the values
+                              necessary to reference another k8s resource for finding
+                              the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        type: object
                       targetGrants:
                         items:
                           description: "Container for granting information. \n Buckets
@@ -824,6 +872,18 @@ spec:
                               type: string
                             bucket:
                               type: string
+                            bucketRef:
+                              description: Reference field for Bucket
+                              properties:
+                                from:
+                                  description: AWSResourceReference provides all the
+                                    values necessary to reference another k8s resource
+                                    for finding the identifier(Id/ARN/Name)
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
                             encryptionConfiguration:
                               description: Specifies encryption-related information
                                 for an Amazon S3 bucket that is a destination for
@@ -831,6 +891,18 @@ spec:
                               properties:
                                 replicaKMSKeyID:
                                   type: string
+                                replicaKMSKeyRef:
+                                  description: Reference field for ReplicaKMSKeyID
+                                  properties:
+                                    from:
+                                      description: AWSResourceReference provides all
+                                        the values necessary to reference another
+                                        k8s resource for finding the identifier(Id/ARN/Name)
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
                               type: object
                             metrics:
                               description: A container specifying replication metrics-related

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -32,6 +32,20 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - s3.services.k8s.aws
   resources:
   - buckets

--- a/generator.yaml
+++ b/generator.yaml
@@ -26,6 +26,10 @@ resources:
       Analytics:
         custom_field:
           list_of: AnalyticsConfiguration
+      Analytics.StorageClassAnalysis.DataExport.Destination.S3BucketDestination.Bucket:
+        references:
+          resource: Bucket
+          path: Spec.Name
       CORS:
         from:
           operation: PutBucketCors
@@ -34,12 +38,21 @@ resources:
         from:
           operation: PutBucketEncryption
           path: ServerSideEncryptionConfiguration
+      Encryption.Rules.ApplyServerSideEncryptionByDefault.KmsMasterKeyID:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
       IntelligentTiering:
         custom_field:
           list_of: IntelligentTieringConfiguration
       Inventory:
         custom_field:
           list_of: InventoryConfiguration
+      Inventory.Destination.S3BucketDestination.Bucket:
+        references:
+          resource: Bucket
+          path: Spec.Name
       Lifecycle:
         from:
           operation: PutBucketLifecycleConfiguration
@@ -48,6 +61,10 @@ resources:
         from:
           operation: PutBucketLogging
           path: BucketLoggingStatus
+      Logging.LoggingEnabled.TargetBucket:
+        references:
+          resource: Bucket
+          path: Spec.Name
       Metrics:
         custom_field:
           list_of: MetricsConfiguration
@@ -71,6 +88,15 @@ resources:
         from:
           operation: PutBucketReplication
           path: ReplicationConfiguration
+      Replication.Rules.Destination.EncryptionConfiguration.ReplicaKMSKeyID:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
+      Replication.Rules.Destination.Bucket:
+        references:
+          resource: Bucket
+          path: Spec.Name
       RequestPayment:
         from:
           operation: PutBucketRequestPayment

--- a/go.local.mod
+++ b/go.local.mod
@@ -5,8 +5,8 @@ go 1.17
 replace github.com/aws-controllers-k8s/runtime => ../runtime
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.0.0
-	github.com/aws/aws-sdk-go v1.42.0
+	github.com/aws-controllers-k8s/runtime v0.21.0
+	github.com/aws/aws-sdk-go v1.44.93
 	github.com/go-logr/logr v1.2.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	github.com/aws-controllers-k8s/kms-controller v0.1.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -49,10 +50,10 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
-	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
-	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
-	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aws-controllers-k8s/s3-controller
 go 1.17
 
 require (
+	github.com/aws-controllers-k8s/kms-controller v0.1.4
 	github.com/aws-controllers-k8s/runtime v0.22.1
 	github.com/aws/aws-sdk-go v1.44.93
 	github.com/go-logr/logr v1.2.0
@@ -44,7 +45,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
-	github.com/stretchr/objx v0.2.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,9 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aws-controllers-k8s/kms-controller v0.1.4 h1:7qIiLL08VHKetRpsIVunKtDWvoDYBH2xXWbMo41Kfyw=
+github.com/aws-controllers-k8s/kms-controller v0.1.4/go.mod h1:0bNgRWuo6SPV5HtdchweSrQwsMRoRmb68uv61HgAs94=
+github.com/aws-controllers-k8s/runtime v0.21.0/go.mod h1:k7z4qlf6aK1Kzd4ff49wzcyhDKHjWaUpqxrwgl4uS1o=
 github.com/aws-controllers-k8s/runtime v0.22.1 h1:V5AKMBjGmq3sblGYrVYvi+6utW4CiIVotWA60Ym9T84=
 github.com/aws-controllers-k8s/runtime v0.22.1/go.mod h1:k7z4qlf6aK1Kzd4ff49wzcyhDKHjWaUpqxrwgl4uS1o=
 github.com/aws/aws-sdk-go v1.44.93 h1:hAgd9fuaptBatSft27/5eBMdcA8+cIMqo96/tZ6rKl8=

--- a/helm/crds/s3.services.k8s.aws_buckets.yaml
+++ b/helm/crds/s3.services.k8s.aws_buckets.yaml
@@ -111,6 +111,18 @@ spec:
                                       type: string
                                     bucketAccountID:
                                       type: string
+                                    bucketRef:
+                                      description: Reference field for Bucket
+                                      properties:
+                                        from:
+                                          description: AWSResourceReference provides
+                                            all the values necessary to reference
+                                            another k8s resource for finding the identifier(Id/ARN/Name)
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                      type: object
                                     format:
                                       type: string
                                     prefix:
@@ -186,6 +198,18 @@ spec:
                           properties:
                             kmsMasterKeyID:
                               type: string
+                            kmsMasterKeyRef:
+                              description: Reference field for KMSMasterKeyID
+                              properties:
+                                from:
+                                  description: AWSResourceReference provides all the
+                                    values necessary to reference another k8s resource
+                                    for finding the identifier(Id/ARN/Name)
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
                             sseAlgorithm:
                               type: string
                           type: object
@@ -291,6 +315,18 @@ spec:
                               type: string
                             bucket:
                               type: string
+                            bucketRef:
+                              description: Reference field for Bucket
+                              properties:
+                                from:
+                                  description: AWSResourceReference provides all the
+                                    values necessary to reference another k8s resource
+                                    for finding the identifier(Id/ARN/Name)
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
                             encryption:
                               description: Contains the type of server-side encryption
                                 used to encrypt the inventory results.
@@ -491,6 +527,18 @@ spec:
                     properties:
                       targetBucket:
                         type: string
+                      targetBucketRef:
+                        description: Reference field for TargetBucket
+                        properties:
+                          from:
+                            description: AWSResourceReference provides all the values
+                              necessary to reference another k8s resource for finding
+                              the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        type: object
                       targetGrants:
                         items:
                           description: "Container for granting information. \n Buckets
@@ -824,6 +872,18 @@ spec:
                               type: string
                             bucket:
                               type: string
+                            bucketRef:
+                              description: Reference field for Bucket
+                              properties:
+                                from:
+                                  description: AWSResourceReference provides all the
+                                    values necessary to reference another k8s resource
+                                    for finding the identifier(Id/ARN/Name)
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
                             encryptionConfiguration:
                               description: Specifies encryption-related information
                                 for an Amazon S3 bucket that is a destination for
@@ -831,6 +891,18 @@ spec:
                               properties:
                                 replicaKMSKeyID:
                                   type: string
+                                replicaKMSKeyRef:
+                                  description: Reference field for ReplicaKMSKeyID
+                                  properties:
+                                    from:
+                                      description: AWSResourceReference provides all
+                                        the values necessary to reference another
+                                        k8s resource for finding the identifier(Id/ARN/Name)
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
                               type: object
                             metrics:
                               description: A container specifying replication metrics-related

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -47,6 +47,20 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - s3.services.k8s.aws
   resources:
   - buckets


### PR DESCRIPTION
Issue #, if available: Fixes https://github.com/aws-controllers-k8s/community/issues/1649

Description of changes:
Adds reference fields for all references to S3 or KMS objects. There are additional references to Lambda, SNS and SQS fields - under the `Notification` configuration item - that can't be added yet until [an issue with reference field path detection](https://github.com/aws-controllers-k8s/community/issues/1610) is resolved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
