### PR TITLE
Ensure public access is set before policy

### DIFF
--- a/pkg/resource/bucket/hook.go
+++ b/pkg/resource/bucket/hook.go
@@ -121,14 +121,16 @@ func (rm *resourceManager) createPutFields(
 			return errors.Wrapf(err, ErrSyncingPutProperty, "OwnershipControls")
 		}
 	}
-	if r.ko.Spec.Policy != nil {
-		if err := rm.syncPolicy(ctx, r); err != nil {
-			return errors.Wrapf(err, ErrSyncingPutProperty, "Policy")
-		}
-	}
+	// PublicAccessBlock may need to be set in order to use Policy, so sync it
+	// first
 	if r.ko.Spec.PublicAccessBlock != nil {
 		if err := rm.syncPublicAccessBlock(ctx, r); err != nil {
 			return errors.Wrapf(err, ErrSyncingPutProperty, "PublicAccessBlock")
+		}
+	}
+	if r.ko.Spec.Policy != nil {
+		if err := rm.syncPolicy(ctx, r); err != nil {
+			return errors.Wrapf(err, ErrSyncingPutProperty, "Policy")
 		}
 	}
 	if r.ko.Spec.Replication != nil {
@@ -237,14 +239,16 @@ func (rm *resourceManager) customUpdateBucket(
 			return nil, errors.Wrapf(err, ErrSyncingPutProperty, "OwnershipControls")
 		}
 	}
-	if delta.DifferentAt("Spec.Policy") {
-		if err := rm.syncPolicy(ctx, desired); err != nil {
-			return nil, errors.Wrapf(err, ErrSyncingPutProperty, "Policy")
-		}
-	}
+	// PublicAccessBlock may need to be set in order to use Policy, so sync it
+	// first
 	if delta.DifferentAt("Spec.PublicAccessBlock") {
 		if err := rm.syncPublicAccessBlock(ctx, desired); err != nil {
 			return nil, errors.Wrapf(err, ErrSyncingPutProperty, "PublicAccessBlock")
+		}
+	}
+	if delta.DifferentAt("Spec.Policy") {
+		if err := rm.syncPolicy(ctx, desired); err != nil {
+			return nil, errors.Wrapf(err, ErrSyncingPutProperty, "Policy")
 		}
 	}
 	if delta.DifferentAt("Spec.RequestPayment") {


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1796

Description of changes:
Ensures that the bucket hook code syncs the `publicAccessBlock` settings before `policy`, so that policies which expose objects publicly are allowed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
