### PR TITLE
add permission for coordination resource

### DIFF
--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -47,6 +47,15 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
   - s3.services.k8s.aws
   resources:
   - buckets


### PR DESCRIPTION
Fix following error when using controller image version aws-controllers-k8s/s3-controller:1.0.5.

Without this permission, the controller won't start and function.

E0908 00:47:56.549961       1 leaderelection.go:334] error initially
creating leader election record: leases.coordination.k8s.io is
forbidden: User "system:serviceaccount:ack-system:ack-s3-controller"
cannot create resource "leases" in API group "coordination.k8s.io" in
the namespace "ack-system"

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
