### PR TITLE
feat: construct and include bucket ARN in status

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2024-08-06T02:49:23Z"
+  build_date: "2024-08-08T05:43:33Z"
   build_hash: 587b90dc860e91ee9a763e9e3bc4d3f1b2fbddb7
-  go_version: go1.22.5
+  go_version: go1.22.4
   version: v0.36.0
 api_directory_checksum: 82bfc8d45e816b2a02a83a4b7cedd72056accddd
 api_version: v1alpha1

--- a/pkg/resource/bucket/hook.go
+++ b/pkg/resource/bucket/hook.go
@@ -15,6 +15,7 @@ package bucket
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -25,6 +26,19 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/s3-controller/apis/v1alpha1"
 	svcsdk "github.com/aws/aws-sdk-go/service/s3"
 )
+
+// bucketARN returns the ARN of the S3 bucket with the given name.
+func bucketARN(bucketName string) string {
+	// TODO(a-hilaly): I know there could be other partitions, but I'm
+	// not sure how to determine at this level of abstraction. Probably
+	// something the SDK/runtime should handle. For now, we'll just use
+	// the `aws` partition.
+	//
+	// NOTE(a-hilaly): Other parts of ACK also use this default partition
+	// e.g the generated function `ARNFromName` also uses `aws` as the
+	// default partition.
+	return fmt.Sprintf("arn:aws:s3:::%s", bucketName)
+}
 
 var (
 	DefaultAccelerationStatus     = svcsdk.BucketAccelerateStatusSuspended

--- a/pkg/resource/bucket/sdk.go
+++ b/pkg/resource/bucket/sdk.go
@@ -109,6 +109,10 @@ func (rm *resourceManager) sdkFind(
 	if err := rm.addPutFieldsToSpec(ctx, r, ko); err != nil {
 		return nil, err
 	}
+
+	// Set bucket ARN in the output
+	bucketARN := ackv1alpha1.AWSResourceName(bucketARN(*ko.Spec.Name))
+	ko.Status.ACKResourceMetadata.ARN = &bucketARN
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/bucket/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/bucket/sdk_read_many_post_set_output.go.tpl
@@ -1,3 +1,7 @@
 	if err := rm.addPutFieldsToSpec(ctx, r, ko); err != nil {
 		return nil, err
 	}
+
+	// Set bucket ARN in the output
+	bucketARN := ackv1alpha1.AWSResourceName(bucketARN(*ko.Spec.Name))
+	ko.Status.ACKResourceMetadata.ARN = &bucketARN

--- a/test/e2e/tests/test_bucket.py
+++ b/test/e2e/tests/test_bucket.py
@@ -114,6 +114,10 @@ def basic_bucket(s3_client) -> Generator[Bucket, None, None]:
     try:
         bucket = create_bucket("bucket")
         assert k8s.get_resource_exists(bucket.ref)
+        
+        # assert bucket ARN is present in status
+        bucket_k8s = bucket.resource_data = k8s.get_resource(bucket.ref)
+        assert "arn:aws:s3:::" + bucket.resource_name == bucket_k8s["status"]["ackResourceMetadata"]["arn"]
 
         exists = bucket_exists(s3_client, bucket)
         assert exists


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/2124

This patch adds the bucket's ARN to its status, as the S3 API
doesn't provide it directly:

- Add helper function to construct bucket ARNs
- Set constructed ARN in resource status after creation/retrieval
- Update e2e tests to verify ARN presence

A minor addition to improve resource information completeness...
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
