### PR TITLE
Add e2e test that adopts bucket created in cloudformation

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-02-06T03:32:53Z"
-  build_hash: 8762917215d9902b2011a2b0b1b0c776855a683e
-  go_version: go1.23.5
-  version: v0.42.0
+  build_date: "2025-02-17T21:07:14Z"
+  build_hash: 11e0a33c63d0cfcd43042d8f8d07466fc1814135
+  go_version: go1.24.0
+  version: v0.42.0-2-g11e0a33
 api_directory_checksum: 12d59cc27a5fc11bf285d7735d81240e980b1046
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.42.0
+	github.com/aws-controllers-k8s/runtime v0.43.0
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.74.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws-controllers-k8s/runtime v0.42.0 h1:fVb3cOwUtn0ZwTSedapES+Rspb97S8BTxMqXJt6R5uM=
-github.com/aws-controllers-k8s/runtime v0.42.0/go.mod h1:Oy0JKvDxZMZ+SVupm4NZVqP00KLIIAMfk93KnOwlt5c=
+github.com/aws-controllers-k8s/runtime v0.43.0 h1:mCtMHO0rew84VbqotquvBirnKysbao+y2G3QI8bKZxM=
+github.com/aws-controllers-k8s/runtime v0.43.0/go.mod h1:Oy0JKvDxZMZ+SVupm4NZVqP00KLIIAMfk93KnOwlt5c=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=

--- a/pkg/resource/bucket/tags.go
+++ b/pkg/resource/bucket/tags.go
@@ -16,14 +16,18 @@
 package bucket
 
 import (
+	"slices"
+	"strings"
+
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
 
 	svcapitypes "github.com/aws-controllers-k8s/s3-controller/apis/v1alpha1"
 )
 
 var (
-	_ = svcapitypes.Bucket{}
-	_ = acktags.NewTags()
+	_             = svcapitypes.Bucket{}
+	_             = acktags.NewTags()
+	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
 // ToACKTags converts the tags parameter into 'acktags.Tags' shape.
@@ -60,4 +64,45 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		result = append(result, &tag)
 	}
 	return result
+}
+
+// ignoreAWSTags ignores tags that have keys that start with "aws:"
+// is needed to ensure the controller does not attempt to remove
+// tags set by AWS
+// Eg. resources created with cloudformation have tags that cannot be
+// removed by an ACK controller
+func ignoreAWSTags(tags acktags.Tags) {
+	for k := range tags {
+		if strings.HasPrefix(k, "aws:") ||
+			slices.Contains(ACKSystemTags, k) {
+			delete(tags, k)
+		}
+	}
+}
+
+// syncAWSTags ensures AWS-managed tags (prefixed with "aws:") from the latest resource state
+// are preserved in the desired state. This prevents the controller from attempting to
+// modify AWS-managed tags, which would result in an error.
+//
+// AWS-managed tags are automatically added by AWS services (e.g., CloudFormation, Service Catalog)
+// and cannot be modified or deleted through normal tag operations. Common examples include:
+// - aws:cloudformation:stack-name
+// - aws:servicecatalog:productArn
+//
+// Parameters:
+//   - a: The target Tags map to be updated (typically desired state)
+//   - b: The source Tags map containing AWS-managed tags (typically latest state)
+//
+// Example:
+//
+//	latest := Tags{"aws:cloudformation:stack-name": "my-stack", "environment": "prod"}
+//	desired := Tags{"environment": "dev"}
+//	SyncAWSTags(desired, latest)
+//	desired now contains {"aws:cloudformation:stack-name": "my-stack", "environment": "dev"}
+func syncAWSTags(a acktags.Tags, b acktags.Tags) {
+	for k := range b {
+		if strings.HasPrefix(k, "aws:") {
+			a[k] = b[k]
+		}
+	}
 }

--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -20,6 +20,7 @@ from acktest.bootstrapping import Resources
 from acktest.bootstrapping.iam import Role
 from acktest.bootstrapping.s3 import Bucket
 from acktest.bootstrapping.sns import Topic
+from acktest.bootstrapping.cloudformation import Stack
 from e2e import bootstrap_directory
 
 @dataclass
@@ -28,6 +29,7 @@ class BootstrapResources(Resources):
     AdoptionBucket: Bucket
     ReplicationRole: Role
     NotificationTopic: Topic
+    StackBucket: Stack
 
 _bootstrap_resources = None
 

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -21,4 +21,5 @@ REPLACEMENT_VALUES = {
     "ADOPTION_BUCKET_NAME": get_bootstrap_resources().AdoptionBucket.name,
     "REPLICATION_BUCKET_NAME": get_bootstrap_resources().ReplicationBucket.name,
     "NOTIFICATION_TOPIC_ARN": get_bootstrap_resources().NotificationTopic.arn,
+    "STACK_BUCKET_NAME": get_bootstrap_resources().StackBucket.template["Resources"]["MyS3Bucket"]["Properties"]["BucketName"],
 }

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@38ce32256cc2552ab54e190cc8a8618e93af9e0c
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@a49300708a1a5586fec36fd28a2494d9cb2288ab

--- a/test/e2e/resources/bucket_adoption_stack.yaml
+++ b/test/e2e/resources/bucket_adoption_stack.yaml
@@ -1,0 +1,8 @@
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: $STACK_BUCKET_NAME
+  annotations:
+    services.k8s.aws/adoption-policy: $ADOPTION_POLICY
+    services.k8s.aws/adoption-fields: "$ADOPTION_FIELDS"
+    services.k8s.aws/deletion-policy: retain

--- a/test/e2e/tests/test_bucket_adoption_policy.py
+++ b/test/e2e/tests/test_bucket_adoption_policy.py
@@ -30,6 +30,8 @@ from e2e.replacement_values import REPLACEMENT_VALUES
 CREATE_WAIT_AFTER_SECONDS = 10
 MODIFY_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 10
+ACK_SYSTEM_TAG_PREFIX = "services.k8s.aws/"
+AWS_SYSTEM_TAG_PREFIX = "aws:"
 
 class AdoptionPolicy(str, Enum):
     NONE = ""
@@ -66,6 +68,36 @@ def adoption_policy_adopt_bucket(s3_client):
     _, deleted = k8s.delete_custom_resource(ref, DELETE_WAIT_AFTER_SECONDS)
     assert deleted
 
+@pytest.fixture(scope="module")
+def adopt_stack_bucket(s3_client):
+    replacements = REPLACEMENT_VALUES.copy()
+    bucket_name = replacements["STACK_BUCKET_NAME"]
+    replacements["ADOPTION_POLICY"] = AdoptionPolicy.ADOPT
+    replacements["ADOPTION_FIELDS"] = f'{{\\\"name\\\": \\\"{bucket_name}\\\"}}'
+
+    resource_data = load_s3_resource(
+        "bucket_adoption_stack",
+        additional_replacements=replacements,
+    )
+
+    # Create k8s resource
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, "buckets",
+        bucket_name, namespace="default")
+    k8s.create_custom_resource(ref, resource_data)
+
+    time.sleep(CREATE_WAIT_AFTER_SECONDS)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr)
+
+    _, deleted = k8s.delete_custom_resource(ref, DELETE_WAIT_AFTER_SECONDS)
+    assert deleted
+
+
 @service_marker
 @pytest.mark.canary
 class TestAdoptionPolicyBucket:
@@ -101,4 +133,57 @@ class TestAdoptionPolicyBucket:
         versioning = latest.Versioning()
         assert versioning.status == status
 
+    def test_adoption_update_tags(
+        self, s3_client, adopt_stack_bucket, s3_resource
+    ):
+        (ref, cr) = adopt_stack_bucket
 
+        # Spec will be added by controller
+        assert 'spec' in cr
+        assert 'name' in cr['spec']
+        assert 'tagSet' not in cr['spec']['tagging']
+        bucket_name = cr['spec']['name']
+
+        updates = {
+            "spec": {
+                "tagging": {
+                    "tagSet": [
+                        {"key": "newKey", "value": "newVal"}
+                    ]
+                }
+            }
+        }
+
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+        assert cr is not None
+        assert 'spec' in cr
+        assert 'tagging' in cr['spec']
+        assert 'tagSet' in cr['spec']['tagging']
+
+        latest = get_bucket(s3_resource, bucket_name)
+        assert latest is not None
+        tagging = latest.Tagging()
+
+        latest = cleanTags(tagging.tag_set)
+        # +2 here because we want to see if we're also filtering
+        # through the aws tags, besides just the ack tags
+        assert len(tagging.tag_set) > len(latest) + 2
+        desired = cr['spec']['tagging']['tagSet']
+        for i in range(1):
+            assert desired[i]["key"] == latest[i]["Key"]
+            assert desired[i]["value"] == latest[i]["Value"]
+
+
+def cleanTags(tags: list,
+          key_member_name: str = 'Key',
+    ) -> list:
+    if isinstance(tags, list):
+        return [
+            t for t in tags if not t[key_member_name].startswith(AWS_SYSTEM_TAG_PREFIX) 
+                and not t[key_member_name].startswith(ACK_SYSTEM_TAG_PREFIX)
+        ]
+    else:
+        raise RuntimeError('tags parameter can only be list type')


### PR DESCRIPTION
Issue [#2248](https://github.com/aws-controllers-k8s/community/issues/2248)

Description of changes:
This test expects the ACK controller to always ignore AWS tags.
 It also attempts updating the tags and ensures the AWS tags 
injected by cloudformation are still ignored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
