### PR TITLE
Add S3 Bucket `LocationConstraint` Logic and Bucket Name Immutability

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-02-20T18:30:11Z"
+  build_date: "2025-02-21T22:05:26Z"
   build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
   go_version: go1.24.0
   version: v0.43.2
-api_directory_checksum: 72db31f2a497b2114082d97643f7bfbe0bf6d425
+api_directory_checksum: 2108338a86d704419192e545c0bfb433bab8c836
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 9624c46b047ce91bc8039ff874cd7c93b64a0a52
+  file_checksum: 0170e59d23a7c2d7fcc2960ce3f537e348933ded
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/bucket.go
+++ b/apis/v1alpha1/bucket.go
@@ -85,6 +85,7 @@ type BucketSpec struct {
 	// DOC-EXAMPLE-BUCKET--usw2-az1--x-s3). For information about bucket naming
 	// restrictions, see Directory bucket naming rules (https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
 	// in the Amazon S3 User Guide
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	// +kubebuilder:validation:Required
 	Name         *string                    `json:"name"`
 	Notification *NotificationConfiguration `json:"notification,omitempty"`

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -21,6 +21,7 @@ resources:
       Name:
         is_primary_key: true
         is_required: true
+        is_immutable: true
         from:
           operation: CreateBucket
           path: Bucket
@@ -96,6 +97,11 @@ resources:
       errors:
         404:
           code: NoSuchBucket
+      terminal_codes:
+        - PermanentRedirect
+        - InvalidLocationConstraint
+        - MalformedXML
+        - IllegalLocationConstraintException
     hooks:
       delta_pre_compare:
         code: customPreCompare(a, b)

--- a/config/crd/bases/s3.services.k8s.aws_buckets.yaml
+++ b/config/crd/bases/s3.services.k8s.aws_buckets.yaml
@@ -659,6 +659,9 @@ spec:
                   restrictions, see Directory bucket naming rules (https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
                   in the Amazon S3 User Guide
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               notification:
                 description: |-
                   A container for specifying the notification configuration of the bucket.

--- a/generator.yaml
+++ b/generator.yaml
@@ -21,6 +21,7 @@ resources:
       Name:
         is_primary_key: true
         is_required: true
+        is_immutable: true
         from:
           operation: CreateBucket
           path: Bucket
@@ -96,6 +97,11 @@ resources:
       errors:
         404:
           code: NoSuchBucket
+      terminal_codes:
+        - PermanentRedirect
+        - InvalidLocationConstraint
+        - MalformedXML
+        - IllegalLocationConstraintException
     hooks:
       delta_pre_compare:
         code: customPreCompare(a, b)

--- a/helm/crds/s3.services.k8s.aws_buckets.yaml
+++ b/helm/crds/s3.services.k8s.aws_buckets.yaml
@@ -659,6 +659,9 @@ spec:
                   restrictions, see Directory bucket naming rules (https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
                   in the Amazon S3 User Guide
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               notification:
                 description: |-
                   A container for specifying the notification configuration of the bucket.

--- a/templates/hooks/bucket/sdk_create_post_build_request.go.tpl
+++ b/templates/hooks/bucket/sdk_create_post_build_request.go.tpl
@@ -1,6 +1,10 @@
-	if input.CreateBucketConfiguration == nil {
-		input.CreateBucketConfiguration = &svcsdktypes.CreateBucketConfiguration{}
-	}
-	if input.CreateBucketConfiguration.LocationConstraint == "" && rm.awsRegion != "us-east-1" {
-		input.CreateBucketConfiguration.LocationConstraint = svcsdktypes.BucketLocationConstraint(rm.awsRegion)
+
+	if rm.awsRegion != "us-east-1" {
+		// Set default region if not specified
+		if input.CreateBucketConfiguration == nil ||
+			input.CreateBucketConfiguration.LocationConstraint == "" {
+			input.CreateBucketConfiguration = &svcsdktypes.CreateBucketConfiguration{
+				LocationConstraint: svcsdktypes.BucketLocationConstraint(rm.awsRegion),
+			}
+		}
 	}


### PR DESCRIPTION
fixes https://github.com/aws-controllers-k8s/community/issues/2336

Description of changes:

Handles bucket creation in relation to the `LocationConstraint`, particularly for the `us-east-1` region

1. **LocationConstraint Region Behavior**
   - **us-east-1**:  
     - If no `LocationConstraint` is provided, creation succeeds (no `CreateBucketConfiguration` is sent).
     - If a user specifies `LocationConstraint=us-east-1`, S3 returns `InvalidLocationConstraint` (marked as terminal).
     - If a user specifies a different region (e.g., `LocationConstraint=us-west-2`), S3 returns `PermanentRedirect` (also marked as terminal).
     
   - **Non-us-east-1**:  
     - If no `LocationConstraint` is specified, controller defaults it to match its own region, creation succeeds.  
     - If `LocationConstraint` matches the region, creation succeeds.
     - If `LocationConstraint` mismatches the region, terminal error.

2. **Terminal Errors**  
   - `PermanentRedirect`, `InvalidLocationConstraint` and `IllegalLocationConstraintException` are now handled as terminal conditions to avoid repeated reconciles.

3. **Bucket Name Immutability**  
   - Enforced via CRD validation (`x-kubernetes-validations`) and generator config (`is_immutable: true`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
