### PR TITLE
No longer ignore EventBridgeConfiguration

### DIFF
--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -10,8 +10,6 @@ ignore:
   field_paths:
     # We cannot support MFA, so if it is set we cannot unset
     - "VersioningConfiguration.MFADelete"
-    # This subfield struct has no members...
-    - "NotificationConfiguration.EventBridgeConfiguration"
     - CreateBucketInput.CreateBucketConfiguration.Location
     - CreateBucketInput.CreateBucketConfiguration.Bucket
     - LoggingEnabled.TargetObjectKeyFormat

--- a/generator.yaml
+++ b/generator.yaml
@@ -10,8 +10,6 @@ ignore:
   field_paths:
     # We cannot support MFA, so if it is set we cannot unset
     - "VersioningConfiguration.MFADelete"
-    # This subfield struct has no members...
-    - "NotificationConfiguration.EventBridgeConfiguration"
     - CreateBucketInput.CreateBucketConfiguration.Location
     - CreateBucketInput.CreateBucketConfiguration.Bucket
     - LoggingEnabled.TargetObjectKeyFormat


### PR DESCRIPTION
Issue #, if available:

Description of changes:

I am not under the impression that the `NotificationConfiguration.EventBridgeConfiguration` struct is still empty, but rather appears to contain the boolean field `EventBridgeEnabled`. Please see the [UserGuide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-eventbridgeconfiguration.html) for reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
