### PR TITLE
Fix creation of buckets in regions where acceleratation not allowed

### DIFF
--- a/pkg/resource/bucket/hook.go
+++ b/pkg/resource/bucket/hook.go
@@ -316,6 +316,7 @@ func (rm *resourceManager) addPutFieldsToSpec(
 ) (err error) {
 	getAccelerateResponse, err := rm.sdkapi.GetBucketAccelerateConfiguration(ctx, rm.newGetBucketAcceleratePayload(r))
 	if err != nil {
+		rm.log.Error(err, "unable to execute 'GetBucketAccelerateConfiguration'")
 		// This method is not supported in every region, ignore any errors if
 		// we attempt to describe this property in a region in which it's not
 		// supported.

--- a/pkg/resource/bucket/hook.go
+++ b/pkg/resource/bucket/hook.go
@@ -316,7 +316,6 @@ func (rm *resourceManager) addPutFieldsToSpec(
 ) (err error) {
 	getAccelerateResponse, err := rm.sdkapi.GetBucketAccelerateConfiguration(ctx, rm.newGetBucketAcceleratePayload(r))
 	if err != nil {
-		rm.log.Error(err, "unable to execute 'GetBucketAccelerateConfiguration'")
 		// This method is not supported in every region, ignore any errors if
 		// we attempt to describe this property in a region in which it's not
 		// supported.
@@ -324,10 +323,10 @@ func (rm *resourceManager) addPutFieldsToSpec(
 			return err
 		}
 	}
-	if getAccelerateResponse.Status != "" {
-		ko.Spec.Accelerate = rm.setResourceAccelerate(r, getAccelerateResponse)
-	} else {
+	if getAccelerateResponse == nil || getAccelerateResponse.Status == "" {
 		ko.Spec.Accelerate = nil
+	} else {
+		ko.Spec.Accelerate = rm.setResourceAccelerate(r, getAccelerateResponse)
 	}
 
 	listAnalyticsResponse, err := rm.sdkapi.ListBucketAnalyticsConfigurations(ctx, rm.newListBucketAnalyticsPayload(r))


### PR DESCRIPTION
Description of changes:

There were a chnages which causes again an issues with accelerated setting for bucket.
There need to check not only empty status but also a null getAccelerateResponse. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
