### PR TITLE
Force "uRI" in CRD field

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-08-15T00:18:45Z"
+  build_date: "2025-08-21T20:37:57Z"
   build_hash: b6df33f8c7f55b234555c0b578b8de43c74771a8
-  go_version: go1.24.6
+  go_version: go1.25.0
   version: v0.51.0
 api_directory_checksum: 2108338a86d704419192e545c0bfb433bab8c836
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 0170e59d23a7c2d7fcc2960ce3f537e348933ded
+  file_checksum: 00a96da29786586c7a3a59666d5546468e616b48
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -54,6 +54,10 @@ resources:
         from:
           operation: PutBucketLogging
           path: BucketLoggingStatus
+      Logging.LoggingEnabled.TargetGrants.Grantee.URI:
+        # Forcing CRD field to "uRI" to avoid breaking change following
+        # fix in aws-controller-k8s/pkg dependency for URI -> uri. 
+        go_tag: json:"uRI,omitempty"
       Metrics:
         custom_field:
           list_of: MetricsConfiguration

--- a/generator.yaml
+++ b/generator.yaml
@@ -54,6 +54,10 @@ resources:
         from:
           operation: PutBucketLogging
           path: BucketLoggingStatus
+      Logging.LoggingEnabled.TargetGrants.Grantee.URI:
+        # Forcing CRD field to "uRI" to avoid breaking change following
+        # fix in aws-controller-k8s/pkg dependency for URI -> uri. 
+        go_tag: json:"uRI,omitempty"
       Metrics:
         custom_field:
           list_of: MetricsConfiguration


### PR DESCRIPTION
Issue #, if available:
[v0.0.19 release](https://github.com/aws-controllers-k8s/pkg/releases/tag/v0.0.19) of aws-controller-k8s/pkg fixes a bug where "URI" became "uRI" when used in CRD fields. Unfortunately, this bug made it into the s3-controller. Forcing the "uRI" in affected field to maintain existing behavior and avoid breaking change in the Bucket CRD.

Description of changes:
- Apply go_tag in generator.yaml to force      Logging.LoggingEnabled.TargetGrants.Grantee.URI field to "uRI" to avoid breaking change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
