### PR TITLE
Ignore empty website field in adoption

### DIFF
--- a/pkg/resource/bucket/hook.go
+++ b/pkg/resource/bucket/hook.go
@@ -16,6 +16,7 @@ package bucket
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -1685,7 +1686,7 @@ func (rm *resourceManager) syncWebsite(
 	ctx context.Context,
 	r *resource,
 ) (err error) {
-	if r.ko.Spec.Website == nil {
+	if r.ko.Spec.Website == nil || reflect.ValueOf(*r.ko.Spec.Website).IsZero() {
 		return rm.deleteWebsite(ctx, r)
 	}
 	return rm.putWebsite(ctx, r)


### PR DESCRIPTION
Issue [#2542](https://github.com/aws-controllers-k8s/community/issues/2542)

Description of changes:

Check the Website field is empty and avoid calling putWebsite during syncWebsite operation if the struct is empty

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
