### PR TITLE
  fix: resolve race condition in test_adopt_or_create_policy e2e test

### DIFF
--- a/test/e2e/tests/test_bucket_adoption_policy.py
+++ b/test/e2e/tests/test_bucket_adoption_policy.py
@@ -165,15 +165,19 @@ class TestAdoptionPolicyBucket:
 
         latest = get_bucket(s3_resource, bucket_name)
         assert latest is not None
-        tagging = latest.Tagging()
 
         initial_tags = {
             "tag_key": "tag_value"
         }
+
+        # Wait for tags to be applied by the controller
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        # Re-fetch tagging after waiting to get the current state
+        tagging = latest.Tagging()
         tags.assert_ack_system_tags(
             tags=tagging.tag_set,
         )
-        time.sleep(5)
         tags.assert_equal_without_ack_tags(
             expected=initial_tags,
             actual=tagging.tag_set,


### PR DESCRIPTION
  The test was fetching bucket tagging before sleeping, then asserting
  against the stale data. This caused flaky failures when the controller
  hadn't finished applying tags yet, resulting in an empty tag_set.

  Move the sleep before the Tagging() call so we wait for the controller
  to apply tags, then fetch the current state for assertion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
