### PR TITLE
feat: support path-style URLs for S3-compatible services

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-04-23T17:45:02Z"
-  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
+  build_date: "2026-04-28T12:43:50Z"
+  build_hash: 32cbc5732e8a0441fc485c2abe81a96b4111c0ae
   go_version: go1.26.2
-  version: v0.58.1
+  version: v0.58.1-2-g32cbc57
 api_directory_checksum: eacd8486c6745fb88c373c09fd904d2268e5538f
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 9d5be04dbe64f87f04bbad86fb082d702a42b030
+  file_checksum: 76aac1e470ef3d17575e11fc368981510e450fe6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -117,6 +117,8 @@ resources:
         template_path: hooks/bucket/sdk_read_many_post_set_output.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/bucket/sdk_create_post_build_request.go.tpl
+      new_resource_manager_client_options:
+        template_path: hooks/bucket/new_resource_manager_client_options.go.tpl
     find_operation:
       custom_method_name: customFindBucket
     update_operation:

--- a/generator.yaml
+++ b/generator.yaml
@@ -117,6 +117,8 @@ resources:
         template_path: hooks/bucket/sdk_read_many_post_set_output.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/bucket/sdk_create_post_build_request.go.tpl
+      new_resource_manager_client_options:
+        template_path: hooks/bucket/new_resource_manager_client_options.go.tpl
     find_operation:
       custom_method_name: customFindBucket
     update_operation:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/s3-controller
 go 1.25.0
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.58.0
+	github.com/aws-controllers-k8s/runtime v0.58.1
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/aws-controllers-k8s/runtime v0.58.0 h1:PbM3hsM5z66BSPTb2CBBElYmGF3EgSbUO88efLXxL78=
-github.com/aws-controllers-k8s/runtime v0.58.0/go.mod h1:WPlOiAG+xGySh1I076llz5g6nbuUeH62Qxh49hnieGo=
+github.com/aws-controllers-k8s/runtime v0.58.1 h1:FZso3Bwd2JIqglH6cpFurNAWkIyc4Z1qNXE7+t0wxdI=
+github.com/aws-controllers-k8s/runtime v0.58.1/go.mod h1:WPlOiAG+xGySh1I076llz5g6nbuUeH62Qxh49hnieGo=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
 {{- if .Values.aws.allow_unsafe_aws_endpoint_urls }}
         - --allow-unsafe-aws-endpoint-urls
 {{- end }}
+{{- if .Values.aws.endpoint_use_path_style }}
+        - --aws-endpoint-use-path-style
+{{- end }}
 {{- if .Values.log.enable_development_logging }}
         - --enable-development-logging
 {{- end }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -181,6 +181,10 @@
           "type": "boolean",
           "default": false
         },
+        "endpoint_use_path_style": {
+          "type": "boolean",
+          "default": false
+        },
         "credentials": {
           "description": "AWS credentials information",
           "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -92,6 +92,7 @@ aws:
   endpoint_url: ""
   identity_endpoint_url: ""
   allow_unsafe_aws_endpoint_urls: false
+  endpoint_use_path_style: false
   credentials:
     # If specified, Secret with shared credentials file to use.
     secretName: ""

--- a/pkg/resource/bucket/manager.go
+++ b/pkg/resource/bucket/manager.go
@@ -390,7 +390,9 @@ func newResourceManager(
 		rr:           rr,
 		awsAccountID: id,
 		awsRegion:    region,
-		sdkapi:       svcsdk.NewFromConfig(clientcfg),
+		sdkapi: svcsdk.NewFromConfig(clientcfg, func(o *svcsdk.Options) {
+			o.UsePathStyle = cfg.UsePathStyle
+		}),
 	}, nil
 }
 

--- a/templates/hooks/bucket/new_resource_manager_client_options.go.tpl
+++ b/templates/hooks/bucket/new_resource_manager_client_options.go.tpl
@@ -1,0 +1,3 @@
+func(o *svcsdk.Options) {
+	o.UsePathStyle = cfg.UsePathStyle
+}


### PR DESCRIPTION
Issue #, if available: aws-controllers-k8s/community#2237

Description of changes:

In order to support some S3-compatible APIs (e.g. LocalStack on a local dev cluster) it may be necessary to force the S3 client to use "path-style" URLs (e.g. http://host/bucket/key).

This PR registers a new `new_resource_manager_client_options` hook (added in the code generator) and adds a hook template that passes `UsePathStyle` from the controller config to the S3 SDK client, enabling path-style URL addressing required by LocalStack and other S3-compatible services.

Associated PRs:
- [runtime#233](https://github.com/aws-controllers-k8s/runtime/pull/233) adds a new config option to allow configuring `UsePathStyle`.
- [code-generator#684](https://github.com/aws-controllers-k8s/code-generator/pull/684) adds the necessary hook used by _this_ PR to allow configuring the service client based on the new controller config option in the `runtime` PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
