### PR TITLE
fix(test): Fix flaky `test_adopt_or_create_policy` e2e test

### DIFF
--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -27,6 +27,7 @@ from e2e import bootstrap_directory
 class BootstrapResources(Resources):
     ReplicationBucket: Bucket
     AdoptionBucket: Bucket
+    AdoptOrCreateBucket: Bucket
     ReplicationRole: Role
     NotificationTopic: Topic
     StackBucket: Stack

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -19,6 +19,7 @@ from e2e.bootstrap_resources import get_bootstrap_resources
 REPLACEMENT_VALUES = {
     "REPLICATION_ROLE_ARN": get_bootstrap_resources().ReplicationRole.arn,
     "ADOPTION_BUCKET_NAME": get_bootstrap_resources().AdoptionBucket.name,
+    "ADOPT_OR_CREATE_BUCKET_NAME": get_bootstrap_resources().AdoptOrCreateBucket.name,
     "REPLICATION_BUCKET_NAME": get_bootstrap_resources().ReplicationBucket.name,
     "NOTIFICATION_TOPIC_ARN": get_bootstrap_resources().NotificationTopic.arn,
     "STACK_BUCKET_NAME": get_bootstrap_resources().StackBucket.template["Resources"]["MyS3Bucket"]["Properties"]["BucketName"],

--- a/test/e2e/resources/bucket_adopt_or_create.yaml
+++ b/test/e2e/resources/bucket_adopt_or_create.yaml
@@ -7,7 +7,7 @@ metadata:
     services.k8s.aws/adoption-fields: "$ADOPTION_FIELDS"
     services.k8s.aws/deletion-policy: retain
 spec:
-  name: $BUCKET_NAME
+  name: $ADOPT_OR_CREATE_BUCKET_NAME
   tagging:
     tagSet:
       - key: tag_key

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -83,6 +83,7 @@ def service_bootstrap() -> Resources:
     resources = BootstrapResources(
         ReplicationBucket=Bucket("ack-s3-replication", enable_versioning=True),
         AdoptionBucket=Bucket("ack-s3-annotation-adoption", enable_versioning=True),
+        AdoptOrCreateBucket=Bucket("ack-s3-adopt-or-create", enable_versioning=True),
         ReplicationRole=Role("ack-s3-replication-role", "s3.amazonaws.com",
             user_policies=UserPolicies("ack-s3-replication-policy", [replication_policy])
         ),

--- a/test/e2e/tests/test_bucket_adoption_policy.py
+++ b/test/e2e/tests/test_bucket_adoption_policy.py
@@ -19,6 +19,8 @@ import pytest
 import time
 import logging
 
+import botocore.exceptions
+
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
 from acktest import tags as tags
@@ -31,6 +33,8 @@ MODIFY_WAIT_AFTER_SECONDS = 20
 DELETE_WAIT_AFTER_SECONDS = 10
 ACK_SYSTEM_TAG_PREFIX = "services.k8s.aws/"
 AWS_SYSTEM_TAG_PREFIX = "aws:"
+TAG_POLL_MAX_RETRIES = 12
+TAG_POLL_INTERVAL_SECONDS = 5
 
 class AdoptionPolicy(str, Enum):
     NONE = ""
@@ -61,6 +65,14 @@ def bucket_adoption_policy(request, s3_client):
     assert 'resource-name' in data
     resource_name = random_suffix_name(data['resource-name'], 32)
     replacements["RANDOM_BUCKET_NAME"] = resource_name
+
+    # Use a dedicated bucket for adopt-or-create tests so they don't
+    # conflict with the adopt test running in parallel on the same
+    # S3 bucket. The adoption-fields annotation must also point to
+    # the correct bucket for the controller's handlePopulation step.
+    if data.get('bucket-key'):
+        bucket_name = replacements[data['bucket-key']]
+        replacements["ADOPTION_FIELDS"] = f'{{\\\"name\\\": \\\"{bucket_name}\\\"}}'
 
     resource_data = load_s3_resource(
         filename,
@@ -151,7 +163,7 @@ class TestAdoptionPolicyBucket:
         versioning = latest.Versioning()
         assert versioning.status == status
     
-    @pytest.mark.resource_data({'adoption-policy': AdoptionPolicy.ADOPT_OR_CREATE, 'filename': 'bucket_adopt_or_create', 'resource-name': 'adopt-or-create'})
+    @pytest.mark.resource_data({'adoption-policy': AdoptionPolicy.ADOPT_OR_CREATE, 'filename': 'bucket_adopt_or_create', 'resource-name': 'adopt-or-create', 'bucket-key': 'ADOPT_OR_CREATE_BUCKET_NAME'})
     def test_adopt_or_create_policy(
         self, s3_client, bucket_adoption_policy, s3_resource
     ):
@@ -163,17 +175,35 @@ class TestAdoptionPolicyBucket:
         assert 'name' in cr['spec']
         bucket_name = cr['spec']['name']
 
-        latest = get_bucket(s3_resource, bucket_name)
-        assert latest is not None
-        tagging = latest.Tagging()
-
         initial_tags = {
             "tag_key": "tag_value"
         }
+
+        # The adopt-or-create flow may need multiple reconcile loops
+        # before tags are fully synced to AWS, and S3 tagging is
+        # eventually consistent. Poll until the expected user tags
+        # appear rather than relying on a fixed sleep.
+        tagging = None
+        for attempt in range(TAG_POLL_MAX_RETRIES):
+            latest = get_bucket(s3_resource, bucket_name)
+            assert latest is not None
+            try:
+                tagging = latest.Tagging()
+                filtered = [
+                    t for t in tagging.tag_set
+                    if not t['Key'].startswith(ACK_SYSTEM_TAG_PREFIX)
+                    and not t['Key'].startswith(AWS_SYSTEM_TAG_PREFIX)
+                ]
+                if len(filtered) == len(initial_tags):
+                    break
+            except botocore.exceptions.ClientError:
+                pass
+            time.sleep(TAG_POLL_INTERVAL_SECONDS)
+
+        assert tagging is not None, "Timed out waiting for tags to propagate"
         tags.assert_ack_system_tags(
             tags=tagging.tag_set,
         )
-        time.sleep(5)
         tags.assert_equal_without_ack_tags(
             expected=initial_tags,
             actual=tagging.tag_set,


### PR DESCRIPTION
Issue #, if available:

Description of changes:

### Issue

`test_adopt_or_create_policy` fails intermittently with:
```
AssertionError: length of "expected" and "actual" tags is not same
```
where `expected = {'tag_key': 'tag_value'}` but `actual = []`.

### Root Cause

`test_adopt_policy` and `test_adopt_or_create_policy` both operate on the **same bootstrap S3 bucket** (`ADOPTION_BUCKET_NAME`) and run in parallel via pytest-xdist.

The `adopt` test's CR has no user tags in its spec — only ACK system tags get applied. The `adopt-or-create` test's CR has `tag_key: tag_value`. When both reconcile concurrently against the same S3 bucket, the `adopt` CR's `putTagging` call overwrites the bucket's tags with only system tags, wiping out the `tag_key` that the `adopt-or-create` CR just set.

From the controller logs, the race looks like:
```
23:27:10.277Z  putTagging  adopt-or-create-...  → sets tag_key + system tags  ✓
23:27:13.107Z  putTagging  adopt-...             → sets only system tags       ✗ (overwrites tag_key)
```

A secondary issue: the original test fetched `tagging = latest.Tagging()` once, then slept, then asserted on the stale object — so even without the race, it could miss tags not yet propagated by S3's eventual consistency.

### Fix

1. Add a dedicated `AdoptOrCreateBucket` bootstrap resource so the two tests operate on separate S3 buckets
2. Wire the new bucket through `replacement_values.py`, the resource template, and the test fixture via a `bucket-key` marker param
3. Replace the fixed `time.sleep(5)` + stale read with a polling loop that re-fetches S3 tags on each attempt (handles eventual consistency)

### Changes

| File | Change |
|------|--------|
| `test/e2e/bootstrap_resources.py` | Add `AdoptOrCreateBucket` field |
| `test/e2e/service_bootstrap.py` | Bootstrap the new bucket |
| `test/e2e/replacement_values.py` | Expose `ADOPT_OR_CREATE_BUCKET_NAME` |
| `test/e2e/resources/bucket_adopt_or_create.yaml` | Use `$ADOPT_OR_CREATE_BUCKET_NAME` instead of `$BUCKET_NAME` |
| `test/e2e/tests/test_bucket_adoption_policy.py` | Support per-test `bucket-key` in fixture; poll tags instead of fixed sleep |

### Testing

This was validated against the prow controller logs from two consecutive CI runs confirming the parallel `putTagging` race on the shared bucket.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
