### PR TITLE
fix: use Policy comparator for Bucket Policy

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-04-28T21:16:52Z"
+  build_date: "2026-04-30T18:43:38Z"
   build_hash: a8dd015d9d12fcefe9bacd128eed5c2308c19e4d
-  go_version: go1.26.2
+  go_version: go1.26.0
   version: v0.58.1-1-ga8dd015
 api_directory_checksum: eacd8486c6745fb88c373c09fd904d2268e5538f
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 76aac1e470ef3d17575e11fc368981510e450fe6
+  file_checksum: e82f5e93e95edc71b872a87b3457ac9a803143d1
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -72,6 +72,7 @@ resources:
           operation: PutBucketOwnershipControls
           path: OwnershipControls
       Policy:
+        is_iam_policy: true
         from:
           operation: PutBucketPolicy
           path: Policy

--- a/generator.yaml
+++ b/generator.yaml
@@ -72,6 +72,7 @@ resources:
           operation: PutBucketOwnershipControls
           path: OwnershipControls
       Policy:
+        is_iam_policy: true
         from:
           operation: PutBucketPolicy
           path: Policy

--- a/pkg/resource/bucket/delta.go
+++ b/pkg/resource/bucket/delta.go
@@ -293,7 +293,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.Policy, b.ko.Spec.Policy) {
 		delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 	} else if a.ko.Spec.Policy != nil && b.ko.Spec.Policy != nil {
-		if *a.ko.Spec.Policy != *b.ko.Spec.Policy {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.Policy, *b.ko.Spec.Policy); err != nil || !equal {
 			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 		}
 	}


### PR DESCRIPTION
Issue [#2591](https://github.com/aws-controllers-k8s/community/issues/2591)

Description of changes:
This comparator ensures we don't continuosly detect delta on whitespace diffs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
