### PR TITLE
fix: add late_initialize for Encryption and OwnershipControls

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-23T05:04:49Z"
+  build_date: "2026-06-24T20:25:14Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.0
+  go_version: go1.26.4
   version: v0.60.0
-api_directory_checksum: 82eae937654efbb0f91e00b8bfb54d06f92b5d75
+api_directory_checksum: 2413687e9ce9152cf45358d43269c2548e949d56
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: f61dc4673c14b0e475c046ce7a3a77bda0fff5f9
+  file_checksum: adfadf85ac8524c0b88b41fd261311de1b0f0620
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -43,6 +43,8 @@ resources:
       CreateBucketConfiguration.Location.Type:
         go_tag: json:"type,omitempty"
       Encryption:
+        late_initialize:
+          skip_incomplete_check: {}
         from:
           operation: PutBucketEncryption
           path: ServerSideEncryptionConfiguration
@@ -74,6 +76,8 @@ resources:
           operation: PutBucketNotificationConfiguration
           path: NotificationConfiguration
       OwnershipControls:
+        late_initialize:
+          skip_incomplete_check: {}
         from:
           operation: PutBucketOwnershipControls
           path: OwnershipControls

--- a/generator.yaml
+++ b/generator.yaml
@@ -43,6 +43,8 @@ resources:
       CreateBucketConfiguration.Location.Type:
         go_tag: json:"type,omitempty"
       Encryption:
+        late_initialize:
+          skip_incomplete_check: {}
         from:
           operation: PutBucketEncryption
           path: ServerSideEncryptionConfiguration
@@ -74,6 +76,8 @@ resources:
           operation: PutBucketNotificationConfiguration
           path: NotificationConfiguration
       OwnershipControls:
+        late_initialize:
+          skip_incomplete_check: {}
         from:
           operation: PutBucketOwnershipControls
           path: OwnershipControls

--- a/pkg/resource/bucket/manager.go
+++ b/pkg/resource/bucket/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=s3.services.k8s.aws,resources=buckets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=s3.services.k8s.aws,resources=buckets/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{}
+var lateInitializeFieldNames = []string{"Encryption", "OwnershipControls"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -260,7 +260,15 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	observed acktypes.AWSResource,
 	latest acktypes.AWSResource,
 ) acktypes.AWSResource {
-	return latest
+	observedKo := rm.concreteResource(observed).ko.DeepCopy()
+	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.Encryption != nil && latestKo.Spec.Encryption == nil {
+		latestKo.Spec.Encryption = observedKo.Spec.Encryption
+	}
+	if observedKo.Spec.OwnershipControls != nil && latestKo.Spec.OwnershipControls == nil {
+		latestKo.Spec.OwnershipControls = observedKo.Spec.OwnershipControls
+	}
+	return &resource{latestKo}
 }
 
 // IsSynced returns true if the resource is synced.


### PR DESCRIPTION
Issues [#2870](https://github.com/aws-controllers-k8s/community/issues/2870), [#2591](https://github.com/aws-controllers-k8s/community/issues/2591)

Description of changes:
Late initialize fields to avoid getting constant deltas

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
