### PR TITLE
fix: wait for resource synced in accelerate e2e test

### DIFF
--- a/test/e2e/tests/test_bucket.py
+++ b/test/e2e/tests/test_bucket.py
@@ -348,6 +348,8 @@ class TestBucket:
     def _update_assert_accelerate(self, bucket: Bucket, s3_client):
         replace_bucket_spec(bucket, "bucket_accelerate")
 
+        assert k8s.wait_on_condition(bucket.ref, condition.CONDITION_TYPE_RESOURCE_SYNCED, "True", wait_periods=10)
+
         accelerate_configuration = s3_client.get_bucket_accelerate_configuration(Bucket=bucket.resource_name)
 
         desired = bucket.resource_data["spec"]["accelerate"]


### PR DESCRIPTION
## Description

The `_update_assert_accelerate` e2e test was flaky because it queries the AWS API immediately after applying a spec change, relying only on a static `time.sleep(MODIFY_WAIT_AFTER_SECONDS)` within `replace_bucket_spec`. If reconciliation hasn't completed by then, the assertion fails.

### Fix

Added `k8s.wait_on_condition(bucket.ref, condition.CONDITION_TYPE_RESOURCE_SYNCED, "True", wait_periods=10)` after calling `replace_bucket_spec` and before querying AWS. This matches the pattern used in the resource creation fixtures (line 211).

### Testing

This test failure was observed during runtime PR CI validation (https://github.com/aws-controllers-k8s/runtime/pull/255).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.