### PR TITLE
fix: reconcile ObjectLockEnabledForBucket on adopted buckets

### DIFF
--- a/pkg/resource/bucket/hook.go
+++ b/pkg/resource/bucket/hook.go
@@ -660,6 +660,11 @@ func (rm *resourceManager) addPutFieldsToSpec(
 			ko.Spec.ObjectLockConfiguration = rm.setResourceObjectLockConfiguration(getObjectLockConfigResponse)
 		} else {
 			ko.Spec.ObjectLockConfiguration = nil
+			// Reflect that Object Lock is disabled, otherwise ko keeps the
+			// desired value and adopted buckets never get a delta.
+			if ko.Spec.ObjectLockEnabledForBucket != nil {
+				ko.Spec.ObjectLockEnabledForBucket = aws.Bool(false)
+			}
 		}
 	}
 

--- a/pkg/resource/bucket/hook_test.go
+++ b/pkg/resource/bucket/hook_test.go
@@ -189,4 +189,79 @@ func Test_addPutFieldsToSpec_ReadsAllFields(t *testing.T) {
 	assert.Equal("ack", *ko.Spec.Tagging.TagSet[0].Value)
 }
 
+// Test_addPutFieldsToSpec_ObjectLockNotEnabledOnBucket is a regression test
+// for aws-controllers-k8s/community#2965. When the bucket has no Object Lock
+// configuration, the observed spec must report ObjectLockEnabledForBucket as
+// false; it used to keep the stale desired `true` (ko is seeded from a copy
+// of the desired resource), so adopted buckets never produced a delta and
+// Object Lock was never enabled.
+func Test_addPutFieldsToSpec_ObjectLockNotEnabledOnBucket(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	rm := &resourceManager{
+		sdkapi: newMockedSDKClient(nil),
+	}
+
+	desired := newBucketResource("my-adopted-bucket")
+	desired.ko.Spec.ObjectLockEnabledForBucket = boolPtr(true)
+	ko := desired.ko.DeepCopy()
+
+	err := rm.addPutFieldsToSpec(context.Background(), desired, ko)
+	require.NoError(err)
+
+	require.NotNil(ko.Spec.ObjectLockEnabledForBucket)
+	assert.False(*ko.Spec.ObjectLockEnabledForBucket)
+	assert.Nil(ko.Spec.ObjectLockConfiguration)
+}
+
+// Test_addPutFieldsToSpec_ObjectLockUnsetStaysNil verifies the reset only
+// applies when the user set the field, since nil-vs-false would produce a
+// permanent delta for buckets that never asked for Object Lock.
+func Test_addPutFieldsToSpec_ObjectLockUnsetStaysNil(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	rm := &resourceManager{
+		sdkapi: newMockedSDKClient(nil),
+	}
+
+	desired := newBucketResource("my-test-bucket")
+	ko := desired.ko.DeepCopy()
+
+	err := rm.addPutFieldsToSpec(context.Background(), desired, ko)
+	require.NoError(err)
+
+	assert.Nil(ko.Spec.ObjectLockEnabledForBucket)
+}
+
+// Test_addPutFieldsToSpec_ObjectLockEnabledOnBucket verifies a bucket that is
+// already locked produces no delta.
+func Test_addPutFieldsToSpec_ObjectLockEnabledOnBucket(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	rm := &resourceManager{
+		sdkapi: newMockedSDKClient(map[string]opResult{
+			"GetObjectLockConfiguration": {output: &svcsdk.GetObjectLockConfigurationOutput{
+				ObjectLockConfiguration: &svcsdktypes.ObjectLockConfiguration{
+					ObjectLockEnabled: svcsdktypes.ObjectLockEnabledEnabled,
+				},
+			}},
+		}),
+	}
+
+	desired := newBucketResource("my-locked-bucket")
+	desired.ko.Spec.ObjectLockEnabledForBucket = boolPtr(true)
+	ko := desired.ko.DeepCopy()
+
+	err := rm.addPutFieldsToSpec(context.Background(), desired, ko)
+	require.NoError(err)
+
+	require.NotNil(ko.Spec.ObjectLockEnabledForBucket)
+	assert.True(*ko.Spec.ObjectLockEnabledForBucket)
+}
+
 func strPtr(s string) *string { return &s }
+
+func boolPtr(b bool) *bool { return &b }

--- a/test/e2e/resources/bucket_object_lock_enable.yaml
+++ b/test/e2e/resources/bucket_object_lock_enable.yaml
@@ -1,0 +1,9 @@
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: $BUCKET_NAME
+spec:
+  name: $BUCKET_NAME
+  versioning:
+    status: Enabled
+  objectLockEnabledForBucket: true

--- a/test/e2e/tests/test_bucket.py
+++ b/test/e2e/tests/test_bucket.py
@@ -345,6 +345,8 @@ class TestBucket:
         self._update_assert_tagging(basic_bucket, s3_resource)
         self._update_assert_versioning(basic_bucket, s3_resource)
         self._update_assert_website(basic_bucket, s3_resource)
+        # Keep last: Object Lock cannot be disabled again.
+        self._update_assert_object_lock(basic_bucket, s3_client)
 
     def _update_assert_accelerate(self, bucket: Bucket, s3_client):
         replace_bucket_spec(bucket, "bucket_accelerate")
@@ -573,6 +575,16 @@ class TestBucket:
 
         assert desired["errorDocument"]["key"] == latest.error_document["Key"]
         assert desired["indexDocument"]["suffix"] == latest.index_document["Suffix"]
+
+    def _update_assert_object_lock(self, bucket: Bucket, s3_client):
+        replace_bucket_spec(bucket, "bucket_object_lock_enable")
+
+        assert k8s.wait_on_condition(bucket.ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
+        object_lock_config = s3_client.get_object_lock_configuration(Bucket=bucket.resource_name)
+        latest = object_lock_config["ObjectLockConfiguration"]
+
+        assert latest["ObjectLockEnabled"] == "Enabled"
 
     def test_bucket_object_lock_config(self, s3_client):
         bucket = create_bucket("bucket_object_lock")


### PR DESCRIPTION
Fixes aws-controllers-k8s/community#2965

## Problem

`ObjectLockEnabledForBucket` only maps to `CreateBucket` (the `x-amz-bucket-object-lock-enabled` header). When a pre-existing bucket is adopted, `CreateBucket` never runs, so Object Lock is never enabled — and the controller never notices:

`addPutFieldsToSpec` seeds the observed object from a copy of the desired resource. When the bucket has no lock configuration, `GetObjectLockConfiguration` returns `ObjectLockConfigurationNotFoundError` and the else-branch only nils `ko.Spec.ObjectLockConfiguration`, leaving `ObjectLockEnabledForBucket` at the stale desired `true`. The delta sees no difference, `syncObjectLockConfiguration` never runs, and the resource reports `ResourceSynced=True` forever while the bucket silently lacks the WORM protection it was declared with.

## Fix

When `GetObjectLockConfiguration` reports no configuration, reset the observed `ObjectLockEnabledForBucket` to `false` (only when the user set the field — the nil-guard avoids introducing a permanent nil-vs-false delta for resources that never asked for Object Lock).

Observed `false` vs desired `true` then produces a delta, and `customUpdateBucket` already routes `Spec.ObjectLockEnabledForBucket` differences to `syncObjectLockConfiguration`, which calls `PutObjectLockConfiguration(ObjectLockEnabled=Enabled)`. AWS supports enabling Object Lock on existing versioned buckets, so adopted buckets now converge. The field is not marked immutable in `generator.yaml`, so this is a normal update path.

## Testing

Added unit tests on top of the existing `addPutFieldsToSpec` mocked-client harness:

- adopting a lock-less bucket with `objectLockEnabledForBucket: true` → observed spec reports `false` (delta fires; this failed before the fix)
- field unset in the desired spec → stays `nil` (no spurious delta)
- bucket with Object Lock already enabled → observed stays `true` (no delta)

`go build ./...` and `go test ./pkg/...` pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.