### PR TITLE
Support tags at CreateBucket time from Spec.Tagging

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-08-13T23:46:38Z"
+  build_date: "2026-08-14T16:31:37Z"
   build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
   go_version: go1.26.5
   version: v0.62.1
@@ -7,7 +7,7 @@ api_directory_checksum: 2d48bffc5191bcaddb8c962485cf8fad008158c1
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: efec90a92c5b92875337243cdeeea187381429db
+  file_checksum: 447e98bdd3637a33259afe65939a1d37a17e294b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -16,6 +16,10 @@ ignore:
     # This subfield struct has no members...
     - "NotificationConfiguration.EventBridgeConfiguration"
     - LoggingEnabled.TargetObjectKeyFormat
+    # Tags at creation are injected from Spec.Tagging by the
+    # sdk_create_post_build_request hook (see
+    # templates/hooks/bucket/sdk_create_post_build_request.go.tpl);
+    # Spec.Tagging remains the single source of truth for bucket tags.
     - CreateBucketConfiguration.Tags
     # Redundant with ObjectLockEnabledForBucket on CreateBucket
     - "ObjectLockConfiguration.ObjectLockEnabled"

--- a/generator.yaml
+++ b/generator.yaml
@@ -16,6 +16,10 @@ ignore:
     # This subfield struct has no members...
     - "NotificationConfiguration.EventBridgeConfiguration"
     - LoggingEnabled.TargetObjectKeyFormat
+    # Tags at creation are injected from Spec.Tagging by the
+    # sdk_create_post_build_request hook (see
+    # templates/hooks/bucket/sdk_create_post_build_request.go.tpl);
+    # Spec.Tagging remains the single source of truth for bucket tags.
     - CreateBucketConfiguration.Tags
     # Redundant with ObjectLockEnabledForBucket on CreateBucket
     - "ObjectLockConfiguration.ObjectLockEnabled"

--- a/pkg/resource/bucket/hook.go
+++ b/pkg/resource/bucket/hook.go
@@ -1773,6 +1773,35 @@ func (rm *resourceManager) putTagging(
 	return nil
 }
 
+// addCreateBucketTags copies ko.Spec.Tagging.TagSet into
+// input.CreateBucketConfiguration.Tags so that tags are applied atomically at
+// bucket creation time. This lets CreateBucket succeed when IAM or SCP
+// policies require tags on the create request (aws:RequestTag conditions).
+// Requires the s3:TagResource permission for general purpose buckets and
+// s3express:TagResource for directory buckets.
+func addCreateBucketTags(
+	ko *svcapitypes.Bucket,
+	input *svcsdk.CreateBucketInput,
+) {
+	if ko.Spec.Tagging == nil || len(ko.Spec.Tagging.TagSet) == 0 {
+		return
+	}
+	tags := make([]svcsdktypes.Tag, 0, len(ko.Spec.Tagging.TagSet))
+	for _, t := range ko.Spec.Tagging.TagSet {
+		if t == nil {
+			continue
+		}
+		tags = append(tags, svcsdktypes.Tag{Key: t.Key, Value: t.Value})
+	}
+	if len(tags) == 0 {
+		return
+	}
+	if input.CreateBucketConfiguration == nil {
+		input.CreateBucketConfiguration = &svcsdktypes.CreateBucketConfiguration{}
+	}
+	input.CreateBucketConfiguration.Tags = tags
+}
+
 func (rm *resourceManager) deleteTagging(
 	ctx context.Context,
 	r *resource,

--- a/pkg/resource/bucket/hook_test.go
+++ b/pkg/resource/bucket/hook_test.go
@@ -388,3 +388,53 @@ func Test_lateInitializeFromReadOneOutput_ABAC(t *testing.T) {
 func strPtr(s string) *string { return &s }
 
 func boolPtr(b bool) *bool { return &b }
+
+// Test_addCreateBucketTags verifies that Spec.Tagging is copied into
+// CreateBucketConfiguration.Tags at creation time (so that tag-on-create
+// IAM/SCP policies using aws:RequestTag conditions are satisfied), without
+// clobbering an already-populated CreateBucketConfiguration.
+func Test_addCreateBucketTags(t *testing.T) {
+	assert := assert.New(t)
+
+	// nil Tagging -> no-op, configuration stays nil
+	r := newBucketResource("mybucket")
+	input := &svcsdk.CreateBucketInput{}
+	addCreateBucketTags(r.ko, input)
+	assert.Nil(input.CreateBucketConfiguration)
+
+	// empty TagSet -> no-op
+	r.ko.Spec.Tagging = &svcapitypes.Tagging{}
+	addCreateBucketTags(r.ko, input)
+	assert.Nil(input.CreateBucketConfiguration)
+
+	// nil-only TagSet entries -> no-op
+	r.ko.Spec.Tagging = &svcapitypes.Tagging{TagSet: []*svcapitypes.Tag{nil}}
+	addCreateBucketTags(r.ko, input)
+	assert.Nil(input.CreateBucketConfiguration)
+
+	// tags set, nil CreateBucketConfiguration -> struct created (us-east-1
+	// path, where the LocationConstraint defaulting leaves the config nil)
+	r.ko.Spec.Tagging = &svcapitypes.Tagging{TagSet: []*svcapitypes.Tag{
+		{Key: strPtr("env"), Value: strPtr("prod")},
+		nil,
+		{Key: strPtr("team"), Value: strPtr("devops")},
+	}}
+	addCreateBucketTags(r.ko, input)
+	require.NotNil(t, input.CreateBucketConfiguration)
+	require.Len(t, input.CreateBucketConfiguration.Tags, 2)
+	assert.Equal("env", *input.CreateBucketConfiguration.Tags[0].Key)
+	assert.Equal("prod", *input.CreateBucketConfiguration.Tags[0].Value)
+	assert.Equal("team", *input.CreateBucketConfiguration.Tags[1].Key)
+	assert.Equal("devops", *input.CreateBucketConfiguration.Tags[1].Value)
+
+	// existing CreateBucketConfiguration (LocationConstraint already
+	// defaulted) is preserved, tags are added alongside it
+	input2 := &svcsdk.CreateBucketInput{
+		CreateBucketConfiguration: &svcsdktypes.CreateBucketConfiguration{
+			LocationConstraint: svcsdktypes.BucketLocationConstraint("eu-west-1"),
+		},
+	}
+	addCreateBucketTags(r.ko, input2)
+	assert.Equal(svcsdktypes.BucketLocationConstraint("eu-west-1"), input2.CreateBucketConfiguration.LocationConstraint)
+	assert.Len(input2.CreateBucketConfiguration.Tags, 2)
+}

--- a/pkg/resource/bucket/sdk.go
+++ b/pkg/resource/bucket/sdk.go
@@ -98,6 +98,15 @@ func (rm *resourceManager) sdkCreate(
 		}
 	}
 
+	// Copy Spec.Tagging into the request's CreateBucketConfiguration.Tags so
+	// that tags are applied at creation time. This allows bucket creation to
+	// succeed under IAM/SCP policies that enforce mandatory tags on
+	// s3:CreateBucket via aws:RequestTag conditions. Spec.Tagging remains the
+	// source of truth; post-create tag updates still flow through
+	// PutBucketTagging. NOTE: this must run after the LocationConstraint
+	// defaulting above, which may replace input.CreateBucketConfiguration.
+	addCreateBucketTags(desired.ko, input)
+
 	var resp *svcsdk.CreateBucketOutput
 	_ = resp
 	resp, err = rm.sdkapi.CreateBucket(ctx, input)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,5 +28,5 @@ var (
 // time and are immutable for the life of the generated code.
 const (
 	ACKGenerateVersion   = "v0.62.1"
-	ACKGenerateBuildDate = "2026-08-13T23:46:38Z"
+	ACKGenerateBuildDate = "2026-08-14T16:31:37Z"
 )

--- a/templates/hooks/bucket/sdk_create_post_build_request.go.tpl
+++ b/templates/hooks/bucket/sdk_create_post_build_request.go.tpl
@@ -17,3 +17,12 @@
 			}
 		}
 	}
+
+	// Copy Spec.Tagging into the request's CreateBucketConfiguration.Tags so
+	// that tags are applied at creation time. This allows bucket creation to
+	// succeed under IAM/SCP policies that enforce mandatory tags on
+	// s3:CreateBucket via aws:RequestTag conditions. Spec.Tagging remains the
+	// source of truth; post-create tag updates still flow through
+	// PutBucketTagging. NOTE: this must run after the LocationConstraint
+	// defaulting above, which may replace input.CreateBucketConfiguration.
+	addCreateBucketTags(desired.ko, input)

--- a/test/e2e/tests/test_bucket.py
+++ b/test/e2e/tests/test_bucket.py
@@ -283,6 +283,28 @@ def basic_bucket(s3_client) -> Generator[Bucket, None, None]:
 
 
 @pytest.fixture(scope="function")
+def tagged_bucket(s3_client) -> Generator[Bucket, None, None]:
+    bucket = None
+    try:
+        bucket = create_bucket("bucket_tagging")
+        assert k8s.get_resource_exists(bucket.ref)
+        k8s.wait_on_condition(bucket.ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
+        exists = bucket_exists(s3_client, bucket)
+        assert exists
+    except:
+        if bucket is not None:
+            delete_bucket(bucket)
+        return pytest.fail("Tagged bucket failed to create")
+
+    yield bucket
+
+    delete_bucket(bucket)
+    exists = bucket_exists(s3_client, bucket)
+    assert not exists
+
+
+@pytest.fixture(scope="function")
 def directory_bucket(s3_client) -> Generator[Bucket, None, None]:
     bucket = None
     try:
@@ -328,6 +350,21 @@ class TestBucket:
     def test_basic(self, basic_bucket):
         # Existance assertions are handled by the fixture
         assert basic_bucket
+
+    def test_create_with_tags(self, s3_resource, tagged_bucket):
+        """Tags declared in spec.tagging must be present on the bucket right
+        after creation: they are passed in the CreateBucket call itself via
+        CreateBucketConfiguration.Tags, so that bucket creation succeeds under
+        IAM/SCP policies enforcing aws:RequestTag conditions on
+        s3:CreateBucket."""
+        latest = get_bucket(s3_resource, tagged_bucket.resource_name)
+        latest_tags = tags.clean(latest.Tagging().tag_set)
+
+        desired = tagged_bucket.resource_data["spec"]["tagging"]["tagSet"]
+        assert len(desired) == len(latest_tags)
+        for i in range(len(desired)):
+            assert desired[i]["key"] == latest_tags[i]["Key"]
+            assert desired[i]["value"] == latest_tags[i]["Value"]
 
     def test_put_fields(self, s3_client, s3_resource, basic_bucket):
         self._update_assert_accelerate(basic_bucket, s3_client)


### PR DESCRIPTION
Fixes aws-controllers-k8s/community#3002

## Problem
Organizations enforcing mandatory tagging via SCPs with `aws:RequestTag`
conditions on `s3:CreateBucket` cannot use this controller: tags are applied
only after creation (`PutBucketTagging`), so every create fails with
`AccessDenied ... explicit deny in a service control policy` and the Bucket
resource loops forever. S3 supports tags at creation time via
`CreateBucketConfiguration.Tags` ([docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-create-tag.html)).

## Solution
Copy `Spec.Tagging.TagSet` into `CreateBucketConfiguration.Tags` inside the
existing `sdk_create_post_build_request` hook, **after** the
LocationConstraint defaulting (which may replace the whole
`CreateBucketConfiguration` struct).

- **No API/CRD change** — `spec.tagging` remains the single source of truth;
  the diff under `helm/crds` and `config/crd` is empty.
- Post-create tag updates keep flowing through `PutBucketTagging`; no drift.
- `CreateBucketConfiguration.Tags` stays in `ignore.field_paths` (comment
  updated to explain why).

## IAM note
Creating a bucket with tags additionally requires `s3:TagResource`
(`s3express:TagResource` for directory buckets). The recommended inline
policy (`s3:*`) already covers it; users with restricted policies need to add
it.

## Testing
- Unit: `Test_addCreateBucketTags` (nil tagging, empty tagSet, nil config /
  us-east-1 path, existing config with LocationConstraint preserved).
- e2e: `test_create_with_tags` asserting `get-bucket-tagging` right after
  create.
- Manual matrix: create with tags in a region ≠ us-east-1 without an explicit
  `createBucketConfiguration` (ordering constraint vs LocationConstraint
  defaulting); us-east-1 (config created by the hook); bucket without
  `spec.tagging` (request identical to today); post-create update via
  `PutBucketTagging` unchanged.
- Validated against a **live tag-enforcement SCP** (deny `s3:CreateBucket`
  unless six mandatory tags are in the request): stock controller fails every
  create, patched controller creates with all tags in the request, tags
  intact after reconcile. This SCP condition is not reproducible in the ACK
  CI, hence the manual validation statement.
