### PR TITLE
chore: remove aws-sdk-go (v1) dependency

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -41,7 +41,6 @@ License Identifier: Apache-2.0
 
 Subdependencies:
 * `github.com/aws-controllers-k8s/runtime`
-* `github.com/aws/aws-sdk-go`
 * `github.com/aws/aws-sdk-go-v2`
 * `github.com/aws/aws-sdk-go-v2/service/iam`
 * `github.com/aws/smithy-go`
@@ -83,7 +82,6 @@ Subdependencies:
 * `github.com/itchyny/gojq`
 * `github.com/itchyny/timefmt-go`
 * `github.com/jaypipes/envutil`
-* `github.com/jmespath/go-jmespath`
 * `github.com/josharian/intern`
 * `github.com/json-iterator/go`
 * `github.com/mailru/easyjson`
@@ -125,10 +123,6 @@ Subdependencies:
 * `sigs.k8s.io/yaml`
 
 #### github.com/aws-controllers-k8s/runtime
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go
 
 License Identifier: Apache-2.0
 
@@ -642,10 +636,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 #### github.com/jaypipes/envutil
-
-License Identifier: Apache-2.0
-
-#### github.com/jmespath/go-jmespath
 
 License Identifier: Apache-2.0
 
@@ -1553,261 +1543,7 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-### github.com/aws-controllers-k8s/runtime
 
-License Identifier: Apache-2.0
-
-Subdependencies:
-* `github.com/aws/aws-sdk-go-v2`
-* `github.com/aws/aws-sdk-go-v2/config`
-* `github.com/aws/aws-sdk-go-v2/credentials`
-* `github.com/aws/aws-sdk-go-v2/service/sts`
-* `github.com/aws/smithy-go`
-* `github.com/cenkalti/backoff/v4`
-* `github.com/go-logr/logr`
-* `github.com/go-logr/zapr`
-* `github.com/google/go-cmp`
-* `github.com/itchyny/gojq`
-* `github.com/jaypipes/envutil`
-* `github.com/micahhausler/aws-iam-policy`
-* `github.com/pkg/errors`
-* `github.com/prometheus/client_golang`
-* `github.com/spf13/pflag`
-* `github.com/stretchr/testify`
-* `go.uber.org/zap`
-* `k8s.io/api`
-* `k8s.io/apimachinery`
-* `k8s.io/client-go`
-* `k8s.io/klog/v2`
-* `k8s.io/utils`
-* `sigs.k8s.io/controller-runtime`
-* `sigs.k8s.io/yaml`
-* `github.com/aws/aws-sdk-go-v2/feature/ec2/imds`
-* `github.com/aws/aws-sdk-go-v2/internal/configsources`
-* `github.com/aws/aws-sdk-go-v2/internal/endpoints/v2`
-* `github.com/aws/aws-sdk-go-v2/internal/ini`
-* `github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding`
-* `github.com/aws/aws-sdk-go-v2/service/internal/presigned-url`
-* `github.com/aws/aws-sdk-go-v2/service/sso`
-* `github.com/aws/aws-sdk-go-v2/service/ssooidc`
-* `github.com/beorn7/perks`
-* `github.com/cespare/xxhash/v2`
-* `github.com/davecgh/go-spew`
-* `github.com/emicklei/go-restful/v3`
-* `github.com/evanphx/json-patch`
-* `github.com/evanphx/json-patch/v5`
-* `github.com/fsnotify/fsnotify`
-* `github.com/fxamacker/cbor/v2`
-* `github.com/go-openapi/jsonpointer`
-* `github.com/go-openapi/jsonreference`
-* `github.com/go-openapi/swag`
-* `github.com/google/btree`
-* `github.com/google/gnostic-models`
-* `github.com/google/uuid`
-* `github.com/itchyny/timefmt-go`
-* `github.com/josharian/intern`
-* `github.com/json-iterator/go`
-* `github.com/mailru/easyjson`
-* `github.com/modern-go/concurrent`
-* `github.com/modern-go/reflect2`
-* `github.com/munnerz/goautoneg`
-* `github.com/pmezard/go-difflib`
-* `github.com/prometheus/client_model`
-* `github.com/prometheus/common`
-* `github.com/prometheus/procfs`
-* `github.com/stretchr/objx`
-* `github.com/x448/float16`
-* `go.uber.org/multierr`
-* `go.yaml.in/yaml/v2`
-* `go.yaml.in/yaml/v3`
-* `golang.org/x/net`
-* `golang.org/x/oauth2`
-* `golang.org/x/sync`
-* `golang.org/x/sys`
-* `golang.org/x/term`
-* `golang.org/x/text`
-* `golang.org/x/time`
-* `gomodules.xyz/jsonpatch/v2`
-* `google.golang.org/protobuf`
-* `gopkg.in/evanphx/json-patch.v4`
-* `gopkg.in/inf.v0`
-* `gopkg.in/yaml.v3`
-* `k8s.io/apiextensions-apiserver`
-* `k8s.io/kube-openapi`
-* `sigs.k8s.io/json`
-* `sigs.k8s.io/randfill`
-* `sigs.k8s.io/structured-merge-diff/v6`
-
-#### github.com/aws/aws-sdk-go-v2
-
-License Identifier: Apache-2.0
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### github.com/evanphx/json-patch
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2014, Evan Phoenix
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of the Evan Phoenix nor the names of its contributors 
-  may be used to endorse or promote products derived from this software 
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### github.com/stretchr/objx
-
-License Identifier: MIT
-
-The MIT License
-
-Copyright (c) 2014 Stretchr, Inc.
-Copyright (c) 2017-2018 objx contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ### github.com/aws/aws-sdk-go-v2
 

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-09-02T22:07:20Z"
+  build_date: "2026-09-08T20:04:06Z"
   build_hash: 177176aa3c632cfbae402dba46e179884777b1de
   go_version: go1.26.5
   version: v0.63.0-7-g177176a

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/s3-controller
 go 1.25.0
 
 require (
-	github.com/aws-controllers-k8s/iam-controller v1.7.2
+	github.com/aws-controllers-k8s/iam-controller v1.9.0
 	github.com/aws-controllers-k8s/runtime v0.63.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
@@ -20,7 +20,6 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go v1.49.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.28.6 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.47 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,9 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/aws-controllers-k8s/iam-controller v1.7.2 h1:voWlgUA8yDTQTGkdKslMydNyY4mXAH8TaRtW4216g0U=
-github.com/aws-controllers-k8s/iam-controller v1.7.2/go.mod h1:GW/KAJdhJ97rhFVJq/8c2iVT4mrA8zi8T4Eu+zhUrqM=
+github.com/aws-controllers-k8s/iam-controller v1.9.0 h1:U3Qn8VMMl5ChxCPhGQvR9O67qONEI7AZYL8b/E2qkwA=
+github.com/aws-controllers-k8s/iam-controller v1.9.0/go.mod h1:/zRo7dH73DS6b/QXbAu5PBvJLSRvRMRcg7hXoVwAqQs=
 github.com/aws-controllers-k8s/runtime v0.63.0 h1:BR8uOwV08AoP5bNS7tlqoLXkSK6E82r7K8fJOuaoVZw=
 github.com/aws-controllers-k8s/runtime v0.63.0/go.mod h1:U0E02HFCvRnLQplApOIeTPDBiRBKXjvyaRhb475bcGs=
-github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
-github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
@@ -99,8 +97,6 @@ github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921i
 github.com/itchyny/timefmt-go v0.1.3/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
 github.com/jaypipes/envutil v1.0.0 h1:u6Vwy9HwruFihoZrL0bxDLCa/YNadGVwKyPElNmZWow=
 github.com/jaypipes/envutil v1.0.0/go.mod h1:vgIRDly+xgBq0eeZRcflOHMMobMwgC6MkMbxo/Nw65M=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,5 +28,5 @@ var (
 // time and are immutable for the life of the generated code.
 const (
 	ACKGenerateVersion   = "v0.63.0-7-g177176a"
-	ACKGenerateBuildDate = "2026-09-02T22:07:20Z"
+	ACKGenerateBuildDate = "2026-09-08T20:04:06Z"
 )


### PR DESCRIPTION
Issue #, if available: aws-controllers-k8s/community#2783

Description of changes:
Bump iam-controller v1.7.2 -> v1.9.0 so no referenced controller pulls aws-sdk-go transitively. aws-sdk-go is now fully absent from go.mod and the module graph.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
